### PR TITLE
[BD-26][EDUCATOR-5791, EDUCATOR-5767] Add handling of exam API errors and support for js workers from provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-lib-special-exams",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3089,21 +3089,39 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.30.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.4.tgz",
-      "integrity": "sha512-GObDVMaI4ARrZEXaRy4moolNAxWPKvEYNV/fa6Uc2eAzR/t4otS6A7EhrntPBIQLeehL9DbVhscvvv7gd6hWqA==",
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.16.3.tgz",
+      "integrity": "sha512-6s13JqQ8yYtlR8RmaoQpxlW/ssMmpWJQo4tAIypoWecX/4JSFCL3h3VLoLphbPLRmn18S4x/BHjT2egkCaYl5Q==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^4.2.2",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.4",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^26.6.2"
+        "@babel/runtime": "^7.10.2",
+        "aria-query": "^4.2.1",
+        "dom-accessibility-api": "^0.4.5",
+        "pretty-format": "^25.5.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3124,9 +3142,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -3153,6 +3171,18 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
         },
         "supports-color": {
           "version": "7.2.0",
@@ -3348,12 +3378,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
-      "dev": true
-    },
-    "@types/aria-query": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
-      "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==",
       "dev": true
     },
     "@types/babel__core": {
@@ -7904,9 +7928,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
-      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.7.tgz",
+      "integrity": "sha512-5+GzhTpCQYHz4NjL8loYTDVBnXIjNLBadWQBKxXk+osFEplLt3EsSYBu2YZcdZ8QqrvCHgW6TSMGMbmgfhrn2g==",
       "dev": true
     },
     "dom-converter": {
@@ -15237,12 +15261,6 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
-    },
-    "lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
-      "dev": true
     },
     "mailto-link": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Special exams lib",
   "main": "dist/index.js",
   "release": {
-    "branches": ["main"]
+    "branches": [
+      "main"
+    ]
   },
   "exports": {
     "import": "./dist/index.js"
@@ -65,6 +67,7 @@
     "@edx/frontend-build": "^5.6.11",
     "@edx/frontend-platform": "1.8.4",
     "@edx/paragon": "13.17.0",
+    "@testing-library/dom": "7.16.3",
     "@testing-library/jest-dom": "5.10.1",
     "@testing-library/react": "10.3.0",
     "axios-mock-adapter": "1.18.2",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,12 @@
 /* eslint-disable import/prefer-default-export */
 export const ExamStatus = Object.freeze({
+  CREATED: 'created',
   STARTED: 'started',
   READY_TO_SUBMIT: 'ready_to_submit',
   SUBMITTED: 'submitted',
   TIMED_OUT: 'timed_out',
+  VERIFIED: 'verified',
+  REJECTED: 'rejected',
 });
 
 export const IS_STARTED_STATUS = (status) => [ExamStatus.STARTED, ExamStatus.READY_TO_SUBMIT].includes(status);

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -17,11 +17,12 @@ export async function pollExamAttempt(url) {
   return data;
 }
 
-export async function createExamAttempt(examId) {
+export async function createExamAttempt(examId, startClock = true, attemptProctored = false) {
   const url = new URL(`${getConfig().LMS_BASE_URL}${BASE_API_URL}`);
   const payload = {
     exam_id: examId,
-    start_clock: 'true',
+    start_clock: startClock.toString(),
+    attempt_proctored: attemptProctored.toString(),
   };
   const { data } = await getAuthenticatedHttpClient().post(url.href, payload);
   return data;
@@ -51,4 +52,10 @@ export async function submitAttempt(attemptId) {
 
 export async function endExamWithFailure(attemptId, error) {
   return updateAttemptStatus(attemptId, ExamAction.ERROR, error);
+}
+
+export async function fetchProctoringSettings(examId) {
+  const url = new URL(`${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/settings/exam_id/${examId}/`);
+  const { data } = await getAuthenticatedHttpClient().get(url.href);
+  return data;
 }

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,6 +1,8 @@
 export {
   getExamAttemptsData,
+  getProctoringSettings,
   startExam,
+  startProctoringExam,
   stopExam,
   continueExam,
   submitExam,

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -6,6 +6,7 @@ export {
   submitExam,
   expireExam,
   pollAttempt,
+  pingAttempt,
 } from './thunks';
 
 export { default as store } from './store';

--- a/src/data/messages/constants.js
+++ b/src/data/messages/constants.js
@@ -1,0 +1,25 @@
+const SUBMIT_MAP = Object.freeze({
+  promptEventName: 'endExamAttempt',
+  successEventName: 'examAttemptEnded',
+  failureEventName: 'examAttemptEndFailed',
+});
+
+const START_MAP = Object.freeze({
+  promptEventName: 'startExamAttempt',
+  successEventName: 'examAttemptStarted',
+  failureEventName: 'examAttemptStartFailed',
+});
+
+const PING_MAP = Object.freeze({
+  promptEventName: 'ping',
+  successEventName: 'echo',
+  failureEventName: 'pingFailed',
+});
+
+const actionToMessageTypesMap = Object.freeze({
+  submit: SUBMIT_MAP,
+  start: START_MAP,
+  ping: PING_MAP,
+});
+
+export default actionToMessageTypesMap;

--- a/src/data/messages/handlers.js
+++ b/src/data/messages/handlers.js
@@ -1,0 +1,44 @@
+import actionToMessageTypesMap from './constants';
+
+function createWorker(url) {
+  const blob = new Blob([`importScripts('${url}');`], { type: 'application/javascript' });
+  const blobUrl = window.URL.createObjectURL(blob);
+  return new Worker(blobUrl);
+}
+
+function workerTimeoutPromise(timeoutMilliseconds) {
+  const message = `worker failed to respond after ${timeoutMilliseconds} ms`;
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject(Error(message));
+    }, timeoutMilliseconds);
+  });
+}
+
+export function workerPromiseForEventNames(eventNames, workerUrl) {
+  return (timeout) => {
+    const proctoringBackendWorker = createWorker(workerUrl);
+    return new Promise((resolve, reject) => {
+      const responseHandler = (e) => {
+        if (e.data.type === eventNames.successEventName) {
+          proctoringBackendWorker.removeEventListener('message', responseHandler);
+          proctoringBackendWorker.terminate();
+          resolve();
+        } else {
+          reject(e.data.error);
+        }
+      };
+      proctoringBackendWorker.addEventListener('message', responseHandler);
+      proctoringBackendWorker.postMessage({ type: eventNames.promptEventName, timeout });
+    });
+  };
+}
+
+export function pingApplication(timeoutInSeconds, workerUrl) {
+  const TIMEOUT_BUFFER_SECONDS = 10;
+  const workerPingTimeout = timeoutInSeconds - TIMEOUT_BUFFER_SECONDS; // 10s buffer for worker to respond
+  return Promise.race([
+    workerPromiseForEventNames(actionToMessageTypesMap.ping, workerUrl)(workerPingTimeout * 1000),
+    workerTimeoutPromise(timeoutInSeconds * 1000),
+  ]);
+}

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -7,6 +7,7 @@ export const examSlice = createSlice({
     isLoading: true,
     timeIsOver: false,
     activeAttempt: null,
+    proctoringSettings: {},
     exam: {},
     apiErrorMsg: '',
   },
@@ -22,6 +23,9 @@ export const examSlice = createSlice({
       state.activeAttempt = payload.activeAttempt;
       state.apiErrorMsg = '';
     },
+    setProctoringSettings: (state, { payload }) => {
+      state.proctoringSettings = payload.proctoringSettings;
+    },
     expireExamAttempt: (state) => {
       state.timeIsOver = true;
     },
@@ -34,7 +38,7 @@ export const examSlice = createSlice({
 
 export const {
   setIsLoading, setExamState, getExamId, expireExamAttempt,
-  setActiveAttempt, setApiError,
+  setActiveAttempt, setProctoringSettings, setApiError,
 } = examSlice.actions;
 
 export default examSlice.reducer;

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -8,6 +8,7 @@ export const examSlice = createSlice({
     timeIsOver: false,
     activeAttempt: null,
     exam: {},
+    apiErrorMsg: '',
   },
   reducers: {
     setIsLoading: (state, { payload }) => {
@@ -19,21 +20,21 @@ export const examSlice = createSlice({
     },
     setActiveAttempt: (state, { payload }) => {
       state.activeAttempt = payload.activeAttempt;
-      const examAttempt = state.exam.attempt;
-      if (examAttempt && examAttempt.attempt_id === payload.activeAttempt.attempt_id) {
-        state.exam.attempt = payload.activeAttempt;
-      }
+      state.apiErrorMsg = '';
     },
     expireExamAttempt: (state) => {
       state.timeIsOver = true;
     },
     getExamId: (state) => state.examId,
+    setApiError: (state, { payload }) => {
+      state.apiErrorMsg = payload.errorMsg;
+    },
   },
 });
 
 export const {
   setIsLoading, setExamState, getExamId, expireExamAttempt,
-  setActiveAttempt,
+  setActiveAttempt, setApiError,
 } = examSlice.actions;
 
 export default examSlice.reducer;

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -6,6 +6,7 @@ import {
   continueAttempt,
   submitAttempt,
   pollExamAttempt,
+  fetchProctoringSettings,
 } from './api';
 import { isEmpty } from '../helpers';
 import {
@@ -14,6 +15,7 @@ import {
   expireExamAttempt,
   setActiveAttempt,
   setApiError,
+  setProctoringSettings,
 } from './slice';
 import { ExamStatus } from '../constants';
 import { workerPromiseForEventNames, pingApplication } from './messages/handlers';
@@ -58,6 +60,20 @@ export function getExamAttemptsData(courseId, sequenceId) {
   return updateAttemptAfter(courseId, sequenceId);
 }
 
+export function getProctoringSettings() {
+  return async (dispatch, getState) => {
+    const { exam } = getState().examState;
+    if (!exam.id) {
+      logError('Failed to get exam settings. No exam id.');
+      return;
+    }
+    dispatch(setIsLoading({ isLoading: true }));
+    const proctoringSettings = await fetchProctoringSettings(exam.id);
+    dispatch(setProctoringSettings({ proctoringSettings }));
+    dispatch(setIsLoading({ isLoading: false }));
+  };
+}
+
 export function startExam() {
   return async (dispatch, getState) => {
     const { exam, activeAttempt } = getState().examState;
@@ -84,6 +100,19 @@ export function startExam() {
         exam.course_id, exam.content_id, createExamAttempt(exam.id),
       )(dispatch);
     }
+  };
+}
+
+export function startProctoringExam() {
+  return async (dispatch, getState) => {
+    const { exam } = getState().examState;
+    if (!exam.id) {
+      logError('Failed to start exam. No exam id.');
+      return;
+    }
+    await updateAttemptAfter(
+      exam.course_id, exam.content_id, createExamAttempt(exam.id, false, true),
+    )(dispatch);
   };
 }
 

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -18,8 +18,8 @@ import ExamAPIError from './ExamAPIError';
 const Exam = ({ isTimeLimited, children }) => {
   const state = useContext(ExamStateContext);
   const {
-    isLoading, activeAttempt, showTimer,
-    stopExam, expireExam, pollAttempt, apiErrorMsg,
+    isLoading, activeAttempt, showTimer, stopExam,
+    expireExam, pollAttempt, apiErrorMsg, pingAttempt,
   } = state;
 
   if (isLoading) {
@@ -40,6 +40,7 @@ const Exam = ({ isTimeLimited, children }) => {
           stopExamAttempt={stopExam}
           expireExamAttempt={expireExam}
           pollExamAttempt={pollAttempt}
+          pingAttempt={pingAttempt}
         />
       )}
       {apiErrorMsg && <ExamAPIError details={apiErrorMsg} />}

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -4,6 +4,7 @@ import { Spinner } from '@edx/paragon';
 import { ExamTimerBlock } from '../timer';
 import Instructions from '../instructions';
 import ExamStateContext from '../context';
+import ExamAPIError from './ExamAPIError';
 
 /**
  * Exam component is intended to render exam instructions before and after exam.
@@ -18,7 +19,7 @@ const Exam = ({ isTimeLimited, children }) => {
   const state = useContext(ExamStateContext);
   const {
     isLoading, activeAttempt, showTimer,
-    stopExam, expireExam, pollAttempt,
+    stopExam, expireExam, pollAttempt, apiErrorMsg,
   } = state;
 
   if (isLoading) {
@@ -41,6 +42,7 @@ const Exam = ({ isTimeLimited, children }) => {
           pollExamAttempt={pollAttempt}
         />
       )}
+      {apiErrorMsg && <ExamAPIError details={apiErrorMsg} />}
       {isTimeLimited
         ? <Instructions>{sequenceContent}</Instructions>
         : sequenceContent}

--- a/src/exam/ExamAPIError.jsx
+++ b/src/exam/ExamAPIError.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Icon } from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+
+// Fixme: Replace with store state data once exam settings are implemented
+const platformName = 'edX';
+const contactUs = 'https://courses.edx.org/support/contact_us';
+
+export default function ExamAPIError({ details }) {
+  return (
+    <Alert variant="danger">
+      <Icon src={Info} className="alert-icon" />
+      <Alert.Heading>
+        <FormattedMessage
+          id="exam.apiError.text"
+          defaultMessage={
+            'A system error has occurred with your exam. '
+              + 'Please reach out to {support_link} for assistance, '
+              + 'and return to the exam once you receive further instructions.'
+          }
+          values={{ support_link: <a href={contactUs} target="_blank" rel="noopener noreferrer">{platformName} Support</a> }}
+        />
+      </Alert.Heading>
+      <p>
+        <FormattedMessage
+          id="exam.apiError.details"
+          defaultMessage="Details"
+        />: {details}
+      </p>
+    </Alert>
+  );
+}
+
+ExamAPIError.propTypes = {
+  details: PropTypes.string.isRequired,
+};

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -10,8 +10,13 @@ const ExamWrapper = ({ children, ...props }) => {
   const state = useContext(ExamStateContext);
   const { sequence, courseId } = props;
 
+  const loadInitialData = async () => {
+    await state.getExamAttemptsData(courseId, sequence.id);
+    state.getProctoringSettings();
+  };
+
   useEffect(() => {
-    state.getExamAttemptsData(courseId, sequence.id);
+    loadInitialData();
   }, []);
 
   return (

--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -1,10 +1,8 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import { render } from '@testing-library/react';
 import SequenceExamWrapper from './ExamWrapper';
 import { store, getExamAttemptsData, startExam } from '../data';
+import { render } from '../setupTest';
 import { ExamStateProvider } from '../index';
 
 jest.mock('../data', () => ({
@@ -27,38 +25,34 @@ store.getState = () => ({
   },
 });
 
-const sequence = {
-  id: 'block-v1:test+test+test+type@sequential+block@5b1bb1aaf6d34e79b213aa37422b4743',
-  isTimeLimited: true,
-};
-const courseId = 'course-v1:test+test+test';
+describe('SequenceExamWrapper', () => {
+  const sequence = {
+    id: 'block-v1:test+test+test+type@sequential+block@5b1bb1aaf6d34e79b213aa37422b4743',
+    isTimeLimited: true,
+  };
+  const courseId = 'course-v1:test+test+test';
 
-test('SequenceExamWrapper is successfully rendered', () => {
-  const { getByTestId } = render(
-    <IntlProvider locale="en">
-      <Provider store={store}>
-        <ExamStateProvider>
-          <SequenceExamWrapper sequence={sequence} courseId={courseId}>
-            <div>children</div>
-          </SequenceExamWrapper>
-        </ExamStateProvider>
-      </Provider>
-    </IntlProvider>,
-  );
-  expect(getByTestId('exam-instructions-title')).toHaveTextContent('Subsection is a Timed Exam (30 minutes)');
-});
+  it('is successfully rendered', () => {
+    const { getByTestId } = render(
+      <ExamStateProvider>
+        <SequenceExamWrapper sequence={sequence} courseId={courseId}>
+          <div>children</div>
+        </SequenceExamWrapper>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(getByTestId('exam-instructions-title')).toHaveTextContent('Subsection is a Timed Exam (30 minutes)');
+  });
 
-test('SequenceExamWrapper does not take any actions if sequence item is not exam', () => {
-  const { getByTestId } = render(
-    <IntlProvider locale="en">
-      <Provider store={store}>
-        <ExamStateProvider>
-          <SequenceExamWrapper sequence={{ ...sequence, isTimeLimited: false }} courseId={courseId}>
-            <div data-testid="sequence-content">children</div>
-          </SequenceExamWrapper>
-        </ExamStateProvider>
-      </Provider>
-    </IntlProvider>,
-  );
-  expect(getByTestId('sequence-content')).toHaveTextContent('children');
+  it('does not take any actions if sequence item is not exam', () => {
+    const { getByTestId } = render(
+      <ExamStateProvider>
+        <SequenceExamWrapper sequence={{ ...sequence, isTimeLimited: false }} courseId={courseId}>
+          <div data-testid="sequence-content">children</div>
+        </SequenceExamWrapper>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(getByTestId('sequence-content')).toHaveTextContent('children');
+  });
 });

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -1,10 +1,8 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { IntlProvider } from 'react-intl';
-import { render } from '@testing-library/react';
-import { Provider } from 'react-redux';
 import Instructions from './index';
 import { store, getExamAttemptsData, startExam } from '../data';
+import { render } from '../setupTest';
 import { ExamStateProvider } from '../index';
 
 jest.mock('../data', () => ({
@@ -17,56 +15,54 @@ startExam.mockReturnValue(jest.fn());
 store.subscribe = jest.fn();
 store.dispatch = jest.fn();
 
-test('Start exam instructions can be successfully rendered', () => {
-  store.getState = () => ({
-    examState: {
-      isLoading: false,
-      activeAttempt: null,
-      exam: {
-        time_limit_mins: 30,
-        attempt: {},
-      },
-    },
-  });
-
-  const { getByTestId } = render(
-    <IntlProvider locale="en">
-      <Provider store={store}>
-        <ExamStateProvider>
-          <Instructions><div>Sequence</div></Instructions>
-        </ExamStateProvider>
-      </Provider>
-    </IntlProvider>,
-  );
-  expect(getByTestId('start-exam-button')).toHaveTextContent('I am ready to start this timed exam.');
-});
-
-test('Instructions are not shown when exam is started', () => {
-  store.getState = () => ({
-    examState: {
-      isLoading: false,
-      activeAttempt: {
-        attempt_status: 'started',
-      },
-      exam: {
-        time_limit_mins: 30,
-        attempt: {
-          attempt_status: 'started',
+describe('SequenceExamWrapper', () => {
+  it('Start exam instructions can be successfully rendered', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        activeAttempt: null,
+        exam: {
+          time_limit_mins: 30,
+          attempt: {},
         },
       },
-    },
+    });
+
+    const { getByTestId } = render(
+      <ExamStateProvider>
+        <Instructions>
+          <div data-testid="sequence-content">Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(getByTestId('start-exam-button')).toHaveTextContent('I am ready to start this timed exam.');
   });
 
-  const { getByTestId } = render(
-    <IntlProvider locale="en">
-      <Provider store={store}>
-        <ExamStateProvider>
-          <Instructions>
-            <div data-testid="sequence-content">Sequence</div>
-          </Instructions>
-        </ExamStateProvider>
-      </Provider>
-    </IntlProvider>,
-  );
-  expect(getByTestId('sequence-content')).toHaveTextContent('Sequence');
+  it('Instructions are not shown when exam is started', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        activeAttempt: {
+          attempt_status: 'started',
+        },
+        exam: {
+          time_limit_mins: 30,
+          attempt: {
+            attempt_status: 'started',
+          },
+        },
+      },
+    });
+
+    const { getByTestId } = render(
+      <ExamStateProvider>
+        <Instructions>
+          <div data-testid="sequence-content">Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(getByTestId('sequence-content')).toHaveTextContent('Sequence');
+  });
 });

--- a/src/instructions/SubmitExamInstructions.jsx
+++ b/src/instructions/SubmitExamInstructions.jsx
@@ -9,7 +9,7 @@ const SubmitExamInstructions = () => {
 
   return (
     <Container className="border py-5 mb-4">
-      <h3 className="h3">
+      <h3 className="h3" data-testid="exam-instructions-title">
         <FormattedMessage
           id="exam.submitExamInstructions.title"
           defaultMessage="Are you sure that you want to submit your timed exam?"

--- a/src/instructions/SubmittedExamInstructions.jsx
+++ b/src/instructions/SubmittedExamInstructions.jsx
@@ -8,7 +8,7 @@ const SubmittedExamInstructions = () => {
 
   return (
     <Container className="border py-5 mb-4">
-      <h3 className="h3">
+      <h3 className="h3" data-testid="exam.submittedExamInstructions.title">
         {state.timeIsOver
           ? (
             <FormattedMessage

--- a/src/instructions/index.jsx
+++ b/src/instructions/index.jsx
@@ -3,21 +3,41 @@ import PropTypes from 'prop-types';
 import StartExamInstructions from './StartExamInstructions';
 import SubmitExamInstructions from './SubmitExamInstructions';
 import SubmittedExamInstructions from './SubmittedExamInstructions';
+import {
+  EntranceProctoredExamInstructions,
+  VerificationProctoredExamInstructions,
+  SubmitProctoredExamInstructions,
+  SubmittedProctoredExamInstructions,
+  VerifiedProctoredExamInstructions,
+  RejectedProctoredExamInstructions,
+} from './proctored_exam';
 import { isEmpty } from '../helpers';
 import { ExamStatus } from '../constants';
 import ExamStateContext from '../context';
 
 const Instructions = ({ children }) => {
   const state = useContext(ExamStateContext);
-  const { attempt } = state.exam;
+  const { attempt, is_proctored: isProctored } = state.exam;
 
   switch (true) {
     case isEmpty(attempt):
-      return <StartExamInstructions />;
+      return isProctored
+        ? <EntranceProctoredExamInstructions />
+        : <StartExamInstructions />;
+    case attempt.attempt_status === ExamStatus.CREATED:
+      return <VerificationProctoredExamInstructions />;
     case attempt.attempt_status === ExamStatus.READY_TO_SUBMIT:
-      return <SubmitExamInstructions />;
+      return isProctored
+        ? <SubmitProctoredExamInstructions />
+        : <SubmitExamInstructions />;
     case attempt.attempt_status === ExamStatus.SUBMITTED:
-      return <SubmittedExamInstructions />;
+      return isProctored
+        ? <SubmittedProctoredExamInstructions />
+        : <SubmittedExamInstructions />;
+    case attempt.attempt_status === ExamStatus.VERIFIED:
+      return <VerifiedProctoredExamInstructions />;
+    case attempt.attempt_status === ExamStatus.REJECTED:
+      return <RejectedProctoredExamInstructions />;
     default:
       return children;
   }

--- a/src/instructions/proctored_exam/EntranceProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/EntranceProctoredExamInstructions.jsx
@@ -1,0 +1,74 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const EntranceProctoredExamInstructions = () => {
+  const state = useContext(ExamStateContext);
+  const { startProctoringExam } = state;
+
+  return (
+    <div>
+      <Container className="border py-5 mb-4">
+        <div className="h3" data-testid="exam-instructions-title">
+          <FormattedMessage
+            id="exam.EntranceProctoredExamInstructions.title"
+            defaultMessage="This exam is proctored"
+          />
+        </div>
+        <p>
+          <FormattedMessage
+            id="exam.EntranceProctoredExamInstructions.text1"
+            defaultMessage={'To be eligible for credit or the program credential associated with this course, '
+            + 'you must pass the proctoring review for this exam.'}
+          />
+        </p>
+        <p className="mt-4 pl-md-4">
+          <FormattedMessage
+            id="exam.EntranceProctoredExamInstructions.text2"
+            defaultMessage="You will be guided through steps to set up online proctoring software and verify your identity."
+          />
+        </p>
+        <p className="pl-md-4">
+          <Button
+            data-testid="start-exam-button"
+            variant="primary"
+            onClick={startProctoringExam}
+          >
+            <FormattedMessage
+              id="exam.startExamInstructions.startExamButtonText"
+              defaultMessage="Continue to my proctored exam."
+            />
+          </Button>
+        </p>
+        <p className="mt-4 pl-md-4 mb-0">
+          <Button
+            data-testid="start-exam-without-proctoring-button"
+            variant="outline-secondary"
+            onClick={() => {}}
+          >
+            <FormattedMessage
+              id="exam.startExamInstructions.startExamButtonText"
+              defaultMessage="Take this exam without proctoring."
+            />
+          </Button>
+        </p>
+      </Container>
+
+      <div className="footer-sequence">
+        <Button
+          data-testid="request-exam-time-button"
+          variant="link"
+          onClick={() => {}}
+        >
+          <FormattedMessage
+            id="exam.startExamInstructions.footerButton"
+            defaultMessage="About Proctored Exams"
+          />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default EntranceProctoredExamInstructions;

--- a/src/instructions/proctored_exam/RejectedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/RejectedProctoredExamInstructions.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@edx/paragon';
+
+const RejectedProctoredExamInstructions = () => (
+  <div>
+    <Container className="border py-5 mb-4 bg-danger-100">
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.RejectedProctoredExamInstructions.title"
+          defaultMessage="Your proctoring session was reviewed, but did not pass all requirements"
+        />
+      </h3>
+      <p className="mb-0">
+        <FormattedMessage
+          id="exam.RejectedProctoredExamInstructions.description"
+          defaultMessage="If you have questions about the status of your proctoring session results, contact platform Support."
+        />
+      </p>
+    </Container>
+
+    <div className="footer-sequence">
+      <p className="ml-3 mb-3 text-gray-500">
+        <FormattedMessage
+          id="exam.RejectedProctoredExamInstructions.note"
+          defaultMessage="If you have concerns about your proctoring session results, contact your course team."
+        />
+      </p>
+      <Button
+        data-testid="request-exam-time-button"
+        variant="link"
+        onClick={() => {}}
+      >
+        <FormattedMessage
+          id="exam.RejectedProctoredExamInstructions.footerButton"
+          defaultMessage="About Proctored Exams"
+        />
+      </Button>
+    </div>
+  </div>
+);
+
+export default RejectedProctoredExamInstructions;

--- a/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmitProctoredExamInstructions.jsx
@@ -1,0 +1,47 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const SubmitProctoredExamInstructions = () => {
+  const state = useContext(ExamStateContext);
+  const { submitExam, continueExam } = state;
+
+  return (
+    <Container className="border py-5 mb-4">
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.SubmitProctoredExamInstructions.title"
+          defaultMessage="Are you sure you want to end your proctored exam?"
+        />
+      </h3>
+      <p>
+        <FormattedMessage
+          id="exam.SubmitProctoredExamInstructions.warningText"
+          defaultMessage='Make sure that you have selected "Submit" for each answer before you submit your exam.'
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="exam.SubmitProctoredExamInstructions.text"
+          defaultMessage='Make sure that you have selected "Submit" for each answer before you submit your exam.'
+        />
+      </p>
+      <Button variant="primary" onClick={submitExam}>
+        <FormattedMessage
+          id="exam.SubmitProctoredExamInstructions.submit"
+          defaultMessage="Yes, end my proctored exam"
+        />
+      </Button>
+      &nbsp;
+      <Button variant="outline-primary" onClick={continueExam}>
+        <FormattedMessage
+          id="exam.SubmitProctoredExamInstructions.continue"
+          defaultMessage="No, I'd like to continue working"
+        />
+      </Button>
+    </Container>
+  );
+};
+
+export default SubmitProctoredExamInstructions;

--- a/src/instructions/proctored_exam/SubmittedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmittedProctoredExamInstructions.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@edx/paragon';
+
+const SubmittedProctoredExamInstructions = () => (
+  <div>
+    <Container className="border py-5 mb-4">
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.title"
+          defaultMessage="You have submitted this proctored exam for review"
+        />
+      </h3>
+      <ul>
+        <li>
+          <FormattedMessage
+            id="exam.SubmittedProctoredExamInstructions.list1"
+            defaultMessage="Your recorded data should now be uploaded for review."
+          />
+          <ul>
+            <li>
+              <FormattedMessage
+                id="exam.SubmittedProctoredExamInstructions.list2"
+                defaultMessage={'If the proctoring software window is still open, close it now and '
+                + 'confirm that you want to quit the application.'}
+              />
+            </li>
+          </ul>
+        </li>
+        <li>
+          <FormattedMessage
+            id="exam.SubmittedProctoredExamInstructions.list3"
+            defaultMessage={'Proctoring results are usually available within 5 business days '
+            + 'after you submit your exam.'}
+          />
+
+        </li>
+      </ul>
+      <p className="mb-0">
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text"
+          defaultMessage={'If you have questions about the status of your proctored exam results, '
+          + 'contact platform Support.'}
+        />
+      </p>
+    </Container>
+
+    <div className="footer-sequence">
+      <Button
+        data-testid="request-exam-time-button"
+        variant="link"
+        onClick={() => {}}
+      >
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.footerButton"
+          defaultMessage="About Proctored Exams"
+        />
+      </Button>
+    </div>
+  </div>
+);
+
+export default SubmittedProctoredExamInstructions;

--- a/src/instructions/proctored_exam/VerificationProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/VerificationProctoredExamInstructions.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@edx/paragon';
+
+const VerificationProctoredExamInstructions = () => (
+  <div>
+    <Container className="border py-5 mb-4">
+      <div className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.VerificationProctoredExamInstructions.title"
+          defaultMessage="Complete your verification before starting the proctored exam."
+        />
+      </div>
+      <p>
+        <FormattedMessage
+          id="exam.VerificationProctoredExamInstructions.text1"
+          defaultMessage="You must successfully complete identity verification before you can start the proctored exam."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="exam.VerificationProctoredExamInstructions.text2"
+          defaultMessage={'Make sure you are on a computer with a webcam, and that you have valid photo '
+          + "identification such as a driver's license or passport, before you continue."}
+        />
+      </p>
+      <Button
+        data-testid="exam.VerificationProctoredExamInstructions-continue-button"
+        variant="outline-secondary"
+        onClick={() => {}}
+      >
+        <FormattedMessage
+          id="exam.VerificationProctoredExamInstructions.continueButton"
+          defaultMessage="Continue to Verification"
+        />
+      </Button>
+    </Container>
+
+    <div className="footer-sequence">
+      <Button
+        data-testid="request-exam-time-button"
+        variant="link"
+        onClick={() => {}}
+      >
+        <FormattedMessage
+          id="exam.startExamInstructions.footerButton"
+          defaultMessage="About Proctored Exams"
+        />
+      </Button>
+    </div>
+  </div>
+);
+
+export default VerificationProctoredExamInstructions;

--- a/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, Container } from '@edx/paragon';
+
+const VerifiedProctoredExamInstructions = () => (
+  <div>
+    <Container className="border py-5 mb-4 bg-success-100">
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.VerifiedProctoredExamInstructions.title"
+          defaultMessage={'Your proctoring session was reviewed successfully. '
+          + 'Go to your progress page to view your exam grade.'}
+        />
+      </h3>
+    </Container>
+
+    <div className="footer-sequence">
+      <Button
+        data-testid="request-exam-time-button"
+        variant="link"
+        onClick={() => {}}
+      >
+        <FormattedMessage
+          id="exam.VerifiedProctoredExamInstructions.footerButton"
+          defaultMessage="About Proctored Exams"
+        />
+      </Button>
+    </div>
+  </div>
+);
+
+export default VerifiedProctoredExamInstructions;

--- a/src/instructions/proctored_exam/index.js
+++ b/src/instructions/proctored_exam/index.js
@@ -1,0 +1,6 @@
+export { default as EntranceProctoredExamInstructions } from './EntranceProctoredExamInstructions';
+export { default as RejectedProctoredExamInstructions } from './RejectedProctoredExamInstructions';
+export { default as SubmitProctoredExamInstructions } from './SubmitProctoredExamInstructions';
+export { default as SubmittedProctoredExamInstructions } from './SubmittedProctoredExamInstructions';
+export { default as VerificationProctoredExamInstructions } from './VerificationProctoredExamInstructions';
+export { default as VerifiedProctoredExamInstructions } from './VerifiedProctoredExamInstructions';

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,1 +1,70 @@
 import 'babel-polyfill';
+import '@testing-library/jest-dom';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import { render as rtlRender } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { IntlProvider } from 'react-intl';
+import examReducer from './data/slice';
+
+window.getComputedStyle = jest.fn(() => ({
+  getPropertyValue: jest.fn(),
+}));
+
+let globalStore;
+
+export async function initializeTestStore(options = null, overrideStore = true) {
+  const preloadedState = options || {
+    examState: {
+      isLoading: true,
+      timeIsOver: false,
+      activeAttempt: {},
+      proctoringSettings: {},
+      exam: {},
+    },
+  };
+  const store = configureStore({
+    reducer: {
+      examState: examReducer,
+    },
+    preloadedState,
+  });
+  if (overrideStore) {
+    globalStore = store;
+  }
+  return store;
+}
+
+function render(
+  ui,
+  {
+    store = null,
+    ...renderOptions
+  } = {},
+) {
+  function Wrapper({ children }) {
+    return (
+      // eslint-disable-next-line react/jsx-filename-extension
+      <IntlProvider locale="en">
+        <Provider store={store || globalStore}>
+          {children}
+        </Provider>
+      </IntlProvider>
+    );
+  }
+
+  Wrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });
+}
+
+// Re-export everything.
+export * from '@testing-library/react';
+
+// Override `render` method.
+export {
+  render,
+};

--- a/src/timer/CountDownTimer.jsx
+++ b/src/timer/CountDownTimer.jsx
@@ -33,8 +33,8 @@ const CountDownTimer = injectIntl((props) => {
           })}
       >
         {isShowTimer
-          ? <Icon src={Visibility} onClick={hideTimer} />
-          : <Icon src={VisibilityOff} onClick={showTimer} />}
+          ? <Icon data-testid="hide-timer" src={Visibility} onClick={hideTimer} />
+          : <Icon data-testid="show-timer" src={VisibilityOff} onClick={showTimer} />}
       </span>
     </div>
   );

--- a/src/timer/CountDownTimer.test.jsx
+++ b/src/timer/CountDownTimer.test.jsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { waitFor } from '@testing-library/dom';
+import { ExamTimerBlock } from './index';
+import {
+  render, screen, initializeTestStore, fireEvent,
+} from '../setupTest';
+import examStore from '../data/store';
+
+jest.mock('../data/store', () => ({
+  examStore: {},
+}));
+
+describe('ExamTimerBlock', () => {
+  let attempt;
+  let store;
+  const stopExamAttempt = () => {};
+  const expireExamAttempt = () => {};
+  const pollAttempt = () => {};
+
+  beforeEach(async () => {
+    const preloadedState = {
+      examState: {
+        isLoading: true,
+        timeIsOver: false,
+        activeAttempt: {
+          attempt_status: 'started',
+          exam_url_path: 'exam_url_path',
+          exam_display_name: 'exam name',
+          time_remaining_seconds: 10,
+          low_threshold_sec: 15,
+          critically_low_threshold_sec: 5,
+          exam_started_poll_url: '',
+          taking_as_proctored: false,
+        },
+        proctoringSettings: {},
+        exam: {},
+      },
+    };
+    store = await initializeTestStore(preloadedState);
+    examStore.getState = store.getState;
+    attempt = store.getState().examState.activeAttempt;
+  });
+
+  it('renders items correctly', async () => {
+    render(
+      <ExamTimerBlock
+        attempt={attempt}
+        stopExamAttempt={stopExamAttempt}
+        expireExamAttempt={expireExamAttempt}
+        pollExamAttempt={pollAttempt}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(attempt.exam_display_name)).toBeInTheDocument();
+    expect(screen.getAllByRole('button').length).toEqual(2);
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'End My Exam' })).toBeInTheDocument();
+  });
+
+  it('renders without activeAttempt return null', async () => {
+    const preloadedState = {
+      examState: {
+        isLoading: true,
+        timeIsOver: false,
+        activeAttempt: null,
+        proctoringSettings: {},
+        exam: {},
+      },
+    };
+    const testStore = await initializeTestStore(preloadedState);
+    attempt = testStore.getState().examState.activeAttempt;
+    const { container } = render(
+      <ExamTimerBlock
+        attempt={attempt}
+        stopExamAttempt={stopExamAttempt}
+        expireExamAttempt={expireExamAttempt}
+        pollExamAttempt={pollAttempt}
+      />,
+    );
+    expect(container.firstChild).not.toBeInTheDocument();
+  });
+
+  it('changes behavior when clock time decreases low threshold', async () => {
+    render(
+      <ExamTimerBlock
+        attempt={attempt}
+        stopExamAttempt={stopExamAttempt}
+        expireExamAttempt={expireExamAttempt}
+        pollExamAttempt={pollAttempt}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('00:00:09')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveClass('alert-warning');
+  });
+
+  it('changes behavior when clock time decreases critically low threshold', async () => {
+    const preloadedState = {
+      examState: {
+        isLoading: true,
+        timeIsOver: false,
+        activeAttempt: {
+          attempt_status: 'started',
+          exam_url_path: 'exam_url_path',
+          exam_display_name: 'exam name',
+          time_remaining_seconds: 5,
+          low_threshold_sec: 15,
+          critically_low_threshold_sec: 5,
+          exam_started_poll_url: '',
+          taking_as_proctored: false,
+        },
+        proctoringSettings: {},
+        exam: {},
+      },
+    };
+    const testStore = await initializeTestStore(preloadedState);
+    examStore.getState = store.testStore;
+    attempt = testStore.getState().examState.activeAttempt;
+    render(
+      <ExamTimerBlock
+        attempt={attempt}
+        stopExamAttempt={stopExamAttempt}
+        expireExamAttempt={expireExamAttempt}
+        pollExamAttempt={pollAttempt}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('00:00:04')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toHaveClass('alert-danger');
+  });
+
+  it('toggles timer visibility correctly', async () => {
+    render(
+      <ExamTimerBlock
+        attempt={attempt}
+        stopExamAttempt={stopExamAttempt}
+        expireExamAttempt={expireExamAttempt}
+        pollExamAttempt={pollAttempt}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('00:00:09')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByLabelText('Hide Timer')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('hide-timer'));
+    expect(screen.getByLabelText('Show Timer')).toBeInTheDocument();
+    expect(screen.queryByText(/00:00:0/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('show-timer'));
+    expect(screen.getByLabelText('Hide Timer')).toBeInTheDocument();
+    expect(screen.queryByText(/00:00:0/)).toBeInTheDocument();
+  });
+
+  it('toggles long text visibility on show more/less', async () => {
+    render(
+      <ExamTimerBlock
+        attempt={attempt}
+        stopExamAttempt={stopExamAttempt}
+        expireExamAttempt={expireExamAttempt}
+        pollExamAttempt={pollAttempt}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('00:00:09')).toBeInTheDocument());
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+    expect(screen.queryByText(/The timer on the right shows the time remaining in the exam./)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show less' }));
+    expect(screen.queryByText(/The timer on the right shows the time remaining in the exam./)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+  });
+});

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -16,7 +16,7 @@ import {
  * Exam timer block component.
  */
 const ExamTimerBlock = injectIntl(({
-  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt, intl,
+  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt, intl, pingAttempt,
 }) => {
   const [isShowMore, showMore, showLess] = useToggle(false);
   const [alertVariant, setAlertVariant] = useState('info');
@@ -41,7 +41,7 @@ const ExamTimerBlock = injectIntl(({
   }, []);
 
   return (
-    <TimerProvider attempt={attempt} pollHandler={pollExamAttempt}>
+    <TimerProvider attempt={attempt} pollHandler={pollExamAttempt} pingHandler={pingAttempt}>
       <Alert variant={alertVariant}>
         <div className="d-flex justify-content-between flex-column flex-lg-row align-items-start">
           <div>

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -70,7 +70,7 @@ const ExamTimerBlock = injectIntl(({
                     <Alert.Link onClick={showLess}>
                       <FormattedMessage
                         id="exam.examTimer.showLessLink"
-                        defaultMessage="Show Less"
+                        defaultMessage="Show less"
                       />
                     </Alert.Link>
                   </span>

--- a/src/timer/TimerProvider.jsx
+++ b/src/timer/TimerProvider.jsx
@@ -27,10 +27,14 @@ const getFormattedRemainingTime = (timeLeft) => ({
   seconds: Math.floor(timeLeft % 60),
 });
 
-const TimerServiceProvider = ({ children, attempt, pollHandler }) => {
+const TimerServiceProvider = ({
+  children, attempt, pollHandler, pingHandler,
+}) => {
   const [timeState, setTimeState] = useState({});
   const [limitReached, setLimitReached] = useToggle(false);
   const {
+    desktop_application_js_url: workerUrl,
+    ping_interval: pingInterval,
     time_remaining_seconds: timeRemaining,
     critically_low_threshold_sec: criticalLowTime,
     low_threshold_sec: lowTime,
@@ -89,6 +93,11 @@ const TimerServiceProvider = ({ children, attempt, pollHandler }) => {
       if (timerTick % POLL_INTERVAL === 0 && secondsLeft >= 0) {
         pollExam();
       }
+
+      // if exam is proctored ping provider app also
+      if (workerUrl && timerTick % pingInterval === pingInterval / 2) {
+        pingHandler(pingInterval, workerUrl);
+      }
     }, 1000);
 
     return () => { clearInterval(interval); };
@@ -111,15 +120,19 @@ TimerServiceProvider.propTypes = {
     critically_low_threshold_sec: PropTypes.number.isRequired,
     low_threshold_sec: PropTypes.number.isRequired,
     exam_started_poll_url: PropTypes.string,
+    desktop_application_js_url: PropTypes.string,
+    ping_interval: PropTypes.number,
     taking_as_proctored: PropTypes.bool,
     attempt_status: PropTypes.string.isRequired,
   }).isRequired,
   children: PropTypes.element.isRequired,
   pollHandler: PropTypes.func,
+  pingHandler: PropTypes.func,
 };
 
 TimerServiceProvider.defaultProps = {
   pollHandler: () => {},
+  pingHandler: () => {},
 };
 
 export default withExamStore(TimerServiceProvider, mapStateToProps);


### PR DESCRIPTION
This PR allows user-friendly handling of exam API errors (previously the errors would just be printed in the console) and also adds support for js workers from proctoring providers

JIRA: [EDUCATOR-5791](https://openedx.atlassian.net/browse/EDUCATOR-5791) [EDUCATOR-5767](https://openedx.atlassian.net/browse/EDUCATOR-5767)