### PR TITLE
[BD-26][EDUCATOR-5808] Part-2 Add additional pages for onboarding / practice exams

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -83,9 +83,3 @@ export async function fetchVerificationStatus() {
   const { data } = await getAuthenticatedHttpClient().get(url.href);
   return data;
 }
-
-export async function getSequenceMetadata(sequenceId) {
-  const url = new URL(`${getConfig().LMS_BASE_URL}/api/courseware/sequence/${sequenceId}`);
-  const { data } = await getAuthenticatedHttpClient().get(url.href);
-  return data;
-}

--- a/src/data/api.js
+++ b/src/data/api.js
@@ -83,3 +83,9 @@ export async function fetchVerificationStatus() {
   const { data } = await getAuthenticatedHttpClient().get(url.href);
   return data;
 }
+
+export async function getSequenceMetadata(sequenceId) {
+  const url = new URL(`${getConfig().LMS_BASE_URL}/api/courseware/sequence/${sequenceId}`);
+  const { data } = await getAuthenticatedHttpClient().get(url.href);
+  return data;
+}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -13,6 +13,7 @@ export {
   getExamReviewPolicy,
   pingAttempt,
   resetExam,
+  getAllowProctoringOptOut,
 } from './thunks';
 
 export { default as store } from './store';

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -7,12 +7,16 @@ export const examSlice = createSlice({
     isLoading: true,
     timeIsOver: false,
     activeAttempt: null,
+    allowProctoringOptOut: false,
     proctoringSettings: {},
     exam: {},
     verification: {},
     apiErrorMsg: '',
   },
   reducers: {
+    setAllowProctoringOptOut: (state, { payload }) => {
+      state.allowProctoringOptOut = payload.allowProctoringOptOut;
+    },
     setIsLoading: (state, { payload }) => {
       state.isLoading = payload.isLoading;
     },
@@ -46,7 +50,7 @@ export const examSlice = createSlice({
 export const {
   setIsLoading, setExamState, getExamId, expireExamAttempt,
   setActiveAttempt, setProctoringSettings, setVerificationData,
-  setReviewPolicy, setApiError,
+  setReviewPolicy, setApiError, setAllowProctoringOptOut,
 } = examSlice.actions;
 
 export default examSlice.reducer;

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -11,6 +11,7 @@ import {
   fetchVerificationStatus,
   fetchExamReviewPolicy,
   resetAttempt,
+  getSequenceMetadata,
 } from './api';
 import { isEmpty } from '../helpers';
 import {
@@ -22,6 +23,7 @@ import {
   setVerificationData,
   setReviewPolicy,
   setApiError,
+  setAllowProctoringOptOut,
 } from './slice';
 import { ExamStatus } from '../constants';
 import { workerPromiseForEventNames, pingApplication } from './messages/handlers';
@@ -357,5 +359,14 @@ export function getExamReviewPolicy() {
     }
     const data = await fetchExamReviewPolicy(exam.id);
     dispatch(setReviewPolicy({ policy: data.review_policy }));
+  };
+}
+
+export function getAllowProctoringOptOut(sequenceId) {
+  return async (dispatch) => {
+    dispatch(setIsLoading({ isLoading: true }));
+    const data = await getSequenceMetadata(sequenceId);
+    dispatch(setAllowProctoringOptOut({ allowProctoringOptOut: data.allow_proctoring_opt_out }));
+    dispatch(setIsLoading({ isLoading: false }));
   };
 }

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -11,7 +11,6 @@ import {
   fetchVerificationStatus,
   fetchExamReviewPolicy,
   resetAttempt,
-  getSequenceMetadata,
 } from './api';
 import { isEmpty } from '../helpers';
 import {
@@ -362,11 +361,8 @@ export function getExamReviewPolicy() {
   };
 }
 
-export function getAllowProctoringOptOut(sequenceId) {
-  return async (dispatch) => {
-    dispatch(setIsLoading({ isLoading: true }));
-    const data = await getSequenceMetadata(sequenceId);
-    dispatch(setAllowProctoringOptOut({ allowProctoringOptOut: data.allow_proctoring_opt_out }));
-    dispatch(setIsLoading({ isLoading: false }));
+export function getAllowProctoringOptOut(allowProctoringOptOut) {
+  return (dispatch) => {
+    dispatch(setAllowProctoringOptOut({ allowProctoringOptOut }));
   };
 }

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -12,6 +12,7 @@ const ExamWrapper = ({ children, ...props }) => {
 
   const loadInitialData = async () => {
     await state.getExamAttemptsData(courseId, sequence.id);
+    await state.getAllowProctoringOptOut(sequence.id);
     state.getProctoringSettings();
   };
 

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -13,7 +13,6 @@ const ExamWrapper = ({ children, ...props }) => {
   const loadInitialData = async () => {
     await state.getExamAttemptsData(courseId, sequence.id);
     state.getProctoringSettings();
-    state.getVerificationData();
   };
 
   useEffect(() => {

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -12,7 +12,7 @@ const ExamWrapper = ({ children, ...props }) => {
 
   const loadInitialData = async () => {
     await state.getExamAttemptsData(courseId, sequence.id);
-    await state.getAllowProctoringOptOut(sequence.id);
+    await state.getAllowProctoringOptOut(sequence.allowProctoringOptOut);
     state.getProctoringSettings();
   };
 
@@ -31,6 +31,7 @@ ExamWrapper.propTypes = {
   sequence: PropTypes.shape({
     id: PropTypes.string.isRequired,
     isTimeLimited: PropTypes.bool,
+    allowProctoringOptOut: PropTypes.bool,
   }).isRequired,
   courseId: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,

--- a/src/instructions/EntranceInstructions.jsx
+++ b/src/instructions/EntranceInstructions.jsx
@@ -4,7 +4,7 @@ import { Container } from '@edx/paragon';
 import { ExamType } from '../constants';
 import { EntranceProctoredExamInstructions } from './proctored_exam';
 import { EntranceOnboardingExamInstructions } from './onboarding_exam';
-import EntrancePracticeExamInstructions from './practice_exam';
+import { EntrancePracticeExamInstructions } from './practice_exam';
 import { StartTimedExamInstructions, TimedExamFooter } from './timed_exam';
 import Footer from './proctored_exam/Footer';
 

--- a/src/instructions/ErrorInstructions.jsx
+++ b/src/instructions/ErrorInstructions.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Container } from '@edx/paragon';
+import { ExamType } from '../constants';
+import { ErrorPracticeExamInstructions } from './practice_exam';
+import { ErrorOnboardingExamInstructions } from './onboarding_exam';
+import { ErrorProctoredExamInstructions } from './proctored_exam';
+import Footer from './proctored_exam/Footer';
+
+const ErrorExamInstructions = ({ examType }) => {
+  const renderInstructions = () => {
+    switch (examType) {
+      case ExamType.ONBOARDING:
+        return <ErrorOnboardingExamInstructions />;
+      case ExamType.PRACTICE:
+        return <ErrorPracticeExamInstructions />;
+      case ExamType.PROCTORED:
+        return <ErrorProctoredExamInstructions />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div>
+      <Container className="border py-5 mb-4">
+        {renderInstructions()}
+      </Container>
+      {examType !== ExamType.TIMED && <Footer />}
+    </div>
+  );
+};
+
+ErrorExamInstructions.propTypes = {
+  examType: PropTypes.string.isRequired,
+};
+
+export default ErrorExamInstructions;

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -161,12 +161,12 @@ describe('SequenceExamWrapper', () => {
       examState: {
         isLoading: false,
         timeIsOver: true,
+        allowProctoringOptOut: true,
         proctoringSettings: {
           platform_name: 'Your Platform',
         },
         activeAttempt: {},
         exam: {
-          allow_proctoring_opt_out: true,
           is_proctored: true,
           time_limit_mins: 30,
           attempt: {},

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -55,14 +55,12 @@ describe('SequenceExamWrapper', () => {
           status: 'none',
           can_verify: true,
         },
-        activeAttempt: {
-          attempt_status: 'started',
-        },
+        activeAttempt: {},
         exam: {
           time_limit_mins: 30,
           type: ExamType.PROCTORED,
           attempt: {
-            attempt_status: 'started',
+            attempt_status: ExamStatus.STARTED,
           },
         },
       },
@@ -261,13 +259,12 @@ describe('SequenceExamWrapper', () => {
           status: 'none',
           can_verify: true,
         },
-        activeAttempt: {
-          attempt_status: 'error',
-        },
+        activeAttempt: {},
         exam: {
+          type: ExamType.PROCTORED,
           time_limit_mins: 30,
           attempt: {
-            attempt_status: 'error',
+            attempt_status: ExamStatus.ERROR,
           },
         },
       },
@@ -296,14 +293,12 @@ describe('SequenceExamWrapper', () => {
           status: 'none',
           can_verify: true,
         },
-        activeAttempt: {
-          attempt_status: 'ready_to_resume',
-        },
+        activeAttempt: {},
         exam: {
-          type: 'proctored',
+          type: ExamType.PROCTORED,
           time_limit_mins: 30,
           attempt: {
-            attempt_status: 'ready_to_resume',
+            attempt_status: ExamStatus.READY_TO_RESUME,
           },
         },
       },
@@ -331,14 +326,12 @@ describe('SequenceExamWrapper', () => {
           can_verify: true,
         },
         proctoringSettings: {},
-        activeAttempt: {
-          attempt_status: 'ready_to_submit',
-        },
+        activeAttempt: {},
         exam: {
-          type: 'timed',
+          type: ExamType.TIMED,
           time_limit_mins: 30,
           attempt: {
-            attempt_status: 'ready_to_submit',
+            attempt_status: ExamStatus.READY_TO_SUBMIT,
           },
         },
       },
@@ -365,13 +358,12 @@ describe('SequenceExamWrapper', () => {
           can_verify: true,
         },
         proctoringSettings: {},
-        activeAttempt: {
-          attempt_status: 'submitted',
-        },
+        activeAttempt: {},
         exam: {
+          type: ExamType.TIMED,
           time_limit_mins: 30,
           attempt: {
-            attempt_status: 'submitted',
+            attempt_status: ExamStatus.SUBMITTED,
           },
         },
       },
@@ -398,13 +390,12 @@ describe('SequenceExamWrapper', () => {
           can_verify: true,
         },
         proctoringSettings: {},
-        activeAttempt: {
-          attempt_status: 'submitted',
-        },
+        activeAttempt: {},
         exam: {
+          type: ExamType.TIMED,
           time_limit_mins: 30,
           attempt: {
-            attempt_status: 'submitted',
+            attempt_status: ExamStatus.SUBMITTED,
           },
         },
       },
@@ -495,5 +486,190 @@ describe('SequenceExamWrapper', () => {
     );
 
     expect(getByTestId('submit-onboarding-exam')).toBeInTheDocument();
+  });
+
+  it('Shows error onboarding exam instructions if exam is onboarding and attempt status is error', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        timeIsOver: false,
+        proctoringSettings: {
+          platform_name: 'Your Platform',
+        },
+        activeAttempt: {},
+        exam: {
+          is_proctored: true,
+          type: ExamType.ONBOARDING,
+          time_limit_mins: 30,
+          attempt: {
+            attempt_status: ExamStatus.ERROR,
+          },
+          prerequisite_status: {},
+        },
+        verification: {},
+      },
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText('Error: There was a problem with your onboarding session')).toBeInTheDocument();
+    expect(screen.getByTestId('retry-exam-button')).toHaveTextContent('Retry my exam');
+  });
+
+  it('Shows submitted onboarding exam instructions if exam is onboarding and attempt status is submitted', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        timeIsOver: false,
+        proctoringSettings: {
+          platform_name: 'Your Platform',
+          integration_specific_email: 'test@example.com',
+          learner_notification_from_email: 'test_notification@example.com',
+        },
+        activeAttempt: {},
+        exam: {
+          is_proctored: true,
+          type: ExamType.ONBOARDING,
+          time_limit_mins: 30,
+          attempt: {
+            attempt_status: ExamStatus.SUBMITTED,
+          },
+          prerequisite_status: {},
+        },
+        verification: {},
+      },
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    const retryExamButton = screen.getByTestId('retry-exam-button');
+    expect(retryExamButton).toHaveTextContent('Retry my exam');
+    expect(screen.getByText('You have submitted this onboarding exam')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'test@example.com' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'test_notification@example.com' })).toBeInTheDocument();
+
+    expect(retryExamButton).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'I understand and want to reset this onboarding exam.' }));
+    expect(retryExamButton).not.toBeDisabled();
+  });
+
+  it('Shows verified onboarding exam instructions if exam is onboarding and attempt status is verified', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        timeIsOver: false,
+        proctoringSettings: {
+          platform_name: 'Your Platform',
+          integration_specific_email: 'test@example.com',
+        },
+        activeAttempt: {},
+        exam: {
+          is_proctored: true,
+          type: ExamType.ONBOARDING,
+          time_limit_mins: 30,
+          attempt: {
+            attempt_status: ExamStatus.VERIFIED,
+          },
+          prerequisite_status: {},
+        },
+        verification: {},
+      },
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText('Your onboarding profile was reviewed successfully')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveTextContent('test@example.com');
+  });
+
+  it('Shows error practice exam instructions if exam is onboarding and attempt status is error', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        timeIsOver: false,
+        proctoringSettings: {
+          platform_name: 'Your Platform',
+        },
+        activeAttempt: {},
+        exam: {
+          is_proctored: true,
+          type: ExamType.PRACTICE,
+          time_limit_mins: 30,
+          attempt: {
+            attempt_status: ExamStatus.ERROR,
+          },
+          prerequisite_status: {},
+        },
+        verification: {},
+      },
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText('There was a problem with your practice proctoring session')).toBeInTheDocument();
+    expect(screen.getByTestId('retry-exam-button')).toHaveTextContent('Retry my exam');
+  });
+
+  it('Shows submitted practice exam instructions if exam is onboarding and attempt status is submitted', () => {
+    store.getState = () => ({
+      examState: {
+        isLoading: false,
+        timeIsOver: false,
+        proctoringSettings: {
+          platform_name: 'Your Platform',
+        },
+        activeAttempt: {},
+        exam: {
+          is_proctored: true,
+          type: ExamType.PRACTICE,
+          time_limit_mins: 30,
+          attempt: {
+            attempt_status: ExamStatus.SUBMITTED,
+          },
+          prerequisite_status: {},
+        },
+        verification: {},
+      },
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText('You have submitted this practice proctored exam')).toBeInTheDocument();
+    expect(screen.getByTestId('retry-exam-button')).toHaveTextContent('Retry my exam');
   });
 });

--- a/src/instructions/SubmittedInstructions.jsx
+++ b/src/instructions/SubmittedInstructions.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Container } from '@edx/paragon';
+import { ExamType } from '../constants';
+import { SubmittedPracticeExamInstructions } from './practice_exam';
+import { SubmittedProctoredExamInstructions } from './proctored_exam';
+import { SubmittedOnboardingExamInstructions } from './onboarding_exam';
+import { SubmittedTimedExamInstructions } from './timed_exam';
+import Footer from './proctored_exam/Footer';
+
+const SubmittedExamInstructions = ({ examType }) => {
+  const renderInstructions = () => {
+    switch (examType) {
+      case ExamType.ONBOARDING:
+        return <SubmittedOnboardingExamInstructions />;
+      case ExamType.PRACTICE:
+        return <SubmittedPracticeExamInstructions />;
+      case ExamType.PROCTORED:
+        return <SubmittedProctoredExamInstructions />;
+      case ExamType.TIMED:
+        return <SubmittedTimedExamInstructions />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div>
+      <Container className="border py-5 mb-4">
+        {renderInstructions()}
+      </Container>
+      {examType !== ExamType.TIMED && <Footer />}
+    </div>
+  );
+};
+
+SubmittedExamInstructions.propTypes = {
+  examType: PropTypes.string.isRequired,
+};
+
+export default SubmittedExamInstructions;

--- a/src/instructions/VerifiedInstructions.jsx
+++ b/src/instructions/VerifiedInstructions.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Container } from '@edx/paragon';
+import { ExamType } from '../constants';
+import { VerifiedOnboardingExamInstructions } from './onboarding_exam';
+import { VerifiedProctoredExamInstructions } from './proctored_exam';
+import Footer from './proctored_exam/Footer';
+
+const VerifiedExamInstructions = ({ examType }) => {
+  const renderInstructions = () => {
+    switch (examType) {
+      case ExamType.ONBOARDING:
+        return <VerifiedOnboardingExamInstructions />;
+      case ExamType.PROCTORED:
+        return <VerifiedProctoredExamInstructions />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div>
+      <Container className="border py-5 mb-4">
+        {renderInstructions()}
+      </Container>
+      {examType !== ExamType.TIMED && <Footer />}
+    </div>
+  );
+};
+
+VerifiedExamInstructions.propTypes = {
+  examType: PropTypes.string.isRequired,
+};
+
+export default VerifiedExamInstructions;

--- a/src/instructions/index.jsx
+++ b/src/instructions/index.jsx
@@ -1,11 +1,7 @@
 import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import SubmittedExamInstructions from './SubmittedExamInstructions';
 import {
-  ErrorProctoredExamInstructions,
   VerificationProctoredExamInstructions,
-  SubmittedProctoredExamInstructions,
-  VerifiedProctoredExamInstructions,
   DownloadSoftwareProctoredExamInstructions,
   ReadyToStartProctoredExamInstructions,
   PrerequisitesProctoredExamInstructions,
@@ -17,6 +13,9 @@ import ExamStateContext from '../context';
 import EntranceExamInstructions from './EntranceInstructions';
 import SubmitExamInstructions from './SubmitInstructions';
 import RejectedInstructions from './RejectedInstructions';
+import ErrorExamInstructions from './ErrorInstructions';
+import SubmittedExamInstructions from './SubmittedInstructions';
+import VerifiedExamInstructions from './VerifiedInstructions';
 
 const Instructions = ({ children }) => {
   const state = useContext(ExamStateContext);
@@ -63,15 +62,13 @@ const Instructions = ({ children }) => {
     case attempt.attempt_status === ExamStatus.READY_TO_SUBMIT:
       return <SubmitExamInstructions examType={examType} />;
     case attempt.attempt_status === ExamStatus.SUBMITTED:
-      return examType === ExamType.PROCTORED
-        ? <SubmittedProctoredExamInstructions />
-        : <SubmittedExamInstructions />;
+      return <SubmittedExamInstructions examType={examType} />;
     case attempt.attempt_status === ExamStatus.VERIFIED:
-      return <VerifiedProctoredExamInstructions />;
+      return <VerifiedExamInstructions examType={examType} />;
     case attempt.attempt_status === ExamStatus.REJECTED:
       return <RejectedInstructions examType={examType} />;
     case attempt.attempt_status === ExamStatus.ERROR:
-      return <ErrorProctoredExamInstructions />;
+      return <ErrorExamInstructions examType={examType} />;
     case attempt.attempt_status === ExamStatus.READY_TO_RESUME:
       return <EntranceExamInstructions examType={examType} skipProctoredExam={toggleSkipProctoredExam} />;
     default:

--- a/src/instructions/onboarding_exam/ErrorOnboardingExamInstructions.jsx
+++ b/src/instructions/onboarding_exam/ErrorOnboardingExamInstructions.jsx
@@ -1,0 +1,39 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const ErrorOnboardingExamInstructions = () => {
+  const state = useContext(ExamStateContext);
+  const { resetExam } = state;
+
+  return (
+    <div>
+      <h3 className="h3">
+        <FormattedMessage
+          id="exam.ErrorOnboardingExamInstructions.title"
+          defaultMessage="Error: There was a problem with your onboarding session"
+        />
+      </h3>
+      <p className="mb-0">
+        <FormattedMessage
+          id="exam.ErrorOnboardingExamInstructions.text"
+          defaultMessage={'Your proctoring session ended before you completed this '
+          + 'onboarding exam. You should retry this onboarding exam'}
+        />
+      </p>
+      <Button
+        data-testid="retry-exam-button"
+        variant="primary"
+        onClick={resetExam}
+      >
+        <FormattedMessage
+          id="exam.ErrorOnboardingExamInstructions.retryExamButton"
+          defaultMessage="Retry my exam"
+        />
+      </Button>
+    </div>
+  );
+};
+
+export default ErrorOnboardingExamInstructions;

--- a/src/instructions/onboarding_exam/SubmittedOnboardingExamInstructions.jsx
+++ b/src/instructions/onboarding_exam/SubmittedOnboardingExamInstructions.jsx
@@ -1,0 +1,98 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button, MailtoLink, useToggle } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const SubmittedOnboardingExamInstructions = () => {
+  const [isConfirm, confirm] = useToggle(false);
+  const state = useContext(ExamStateContext);
+  const { proctoringSettings, resetExam } = state;
+  const {
+    learner_notification_from_email: learnerNotificationFromEmail,
+    integration_specific_email: integrationSpecificEmail,
+  } = proctoringSettings || {};
+
+  return (
+    <div>
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.SubmittedOnboardingExamInstructions.title"
+          defaultMessage="You have submitted this onboarding exam"
+        />
+      </h3>
+      <p>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text1"
+          defaultMessage={'If you do not have an onboarding profile with the system, Verificient '
+          + 'will review your submission and create an onboarding profile to grant you access to '
+          + 'proctored exams. Onboarding profile review can take 2+ business days.'}
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text2"
+          defaultMessage={'Once your profile has been reviewed, you will receive an email with '
+          + 'review results. The email will come from '}
+        />
+        <MailtoLink to={learnerNotificationFromEmail}>
+          {learnerNotificationFromEmail}
+        </MailtoLink>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text3"
+          defaultMessage={', so make sure this email has been added '
+          + 'to your inbox filter.'}
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text4"
+          defaultMessage={'If you do not have an onboarding profile with the system, Verificient '
+          + 'will review your submission and create an onboarding profile to grant you access to '
+          + 'proctored exams. Onboarding profile review can take 2+ business days.'}
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text5"
+          defaultMessage={'If you already have an onboarding profile approved through another course, '
+          + 'this submission will not be reviewed. You may retry this exam at any time to validate that '
+          + 'your setup still meets the requirements for proctoring.'}
+        />
+      </p>
+      <p>
+        <Button variant="link" onClick={confirm}>
+          <FormattedMessage
+            id="exam.SubmittedProctoredExamInstructions.confirm"
+            defaultMessage="I understand and want to reset this onboarding exam."
+          />
+        </Button>
+      </p>
+      <Button
+        data-testid="retry-exam-button"
+        variant="primary"
+        onClick={resetExam}
+        disabled={!isConfirm}
+      >
+        <FormattedMessage
+          id="exam.ErrorOnboardingExamInstructions.retryExamButton"
+          defaultMessage="Retry my exam"
+        />
+      </Button>
+      <p className="mt-4">
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text6"
+          defaultMessage="Please contact "
+        />
+        <MailtoLink to={integrationSpecificEmail}>
+          {integrationSpecificEmail}
+        </MailtoLink>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text7"
+          defaultMessage=" if you have questions."
+        />
+      </p>
+    </div>
+  );
+};
+
+export default SubmittedOnboardingExamInstructions;

--- a/src/instructions/onboarding_exam/VerifiedOnboardingExamInstructions.jsx
+++ b/src/instructions/onboarding_exam/VerifiedOnboardingExamInstructions.jsx
@@ -1,0 +1,44 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { MailtoLink } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const VerifiedOnboardingExamInstructions = () => {
+  const state = useContext(ExamStateContext);
+  const {
+    integration_specific_email: integrationSpecificEmail,
+  } = state.proctoringSettings || {};
+
+  return (
+    <div>
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.VerifiedOnboardingExamInstructions.title"
+          defaultMessage="Your onboarding profile was reviewed successfully"
+        />
+      </h3>
+      <p>
+        <FormattedMessage
+          id="exam.VerifiedOnboardingExamInstructions.text"
+          defaultMessage={'Your profile has been established, and you\'re ready '
+          + 'to take proctored exams in this course'}
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="exam.VerifiedOnboardingExamInstructions.helpText1"
+          defaultMessage="Please contact "
+        />
+        <MailtoLink to={integrationSpecificEmail}>
+          {integrationSpecificEmail}
+        </MailtoLink>
+        <FormattedMessage
+          id="exam.VerifiedOnboardingExamInstructions.helpText2"
+          defaultMessage=" if you have questions."
+        />
+      </p>
+    </div>
+  );
+};
+
+export default VerifiedOnboardingExamInstructions;

--- a/src/instructions/onboarding_exam/index.js
+++ b/src/instructions/onboarding_exam/index.js
@@ -1,2 +1,5 @@
 export { default as EntranceOnboardingExamInstructions } from './EntranceOnboardingExamInstructions';
 export { default as RejectedOnboardingExamInstructions } from './RejectedOnboardingExamInstructions';
+export { default as ErrorOnboardingExamInstructions } from './ErrorOnboardingExamInstructions';
+export { default as SubmittedOnboardingExamInstructions } from './SubmittedOnboardingExamInstructions';
+export { default as VerifiedOnboardingExamInstructions } from './VerifiedOnboardingExamInstructions';

--- a/src/instructions/practice_exam/ErrorPracticeExamInstructions.jsx
+++ b/src/instructions/practice_exam/ErrorPracticeExamInstructions.jsx
@@ -1,0 +1,51 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const ErrorPracticeExamInstructions = () => {
+  const state = useContext(ExamStateContext);
+  const { resetExam } = state;
+
+  return (
+    <div>
+      <h3 className="h3">
+        <FormattedMessage
+          id="exam.ErrorPracticeExamInstructions.title"
+          defaultMessage="There was a problem with your practice proctoring session"
+        />
+      </h3>
+      <h4 className="h4">
+        <FormattedMessage
+          id="exam.ErrorPracticeExamInstructions.title2"
+          defaultMessage="Your practice proctoring results: "
+        />
+        <span className="font-weight-bold">
+          <FormattedMessage
+            id="exam.ErrorPracticeExamInstructions.title2.result"
+            defaultMessage="Unsatisfactory"
+          />
+        </span>
+      </h4>
+      <p className="mb-0">
+        <FormattedMessage
+          id="exam.ErrorPracticeExamInstructions.text"
+          defaultMessage={'Your proctoring session ended before you completed this practice exam. '
+          + 'You can retry this practice exam if you had problems setting up the online proctoring software.'}
+        />
+      </p>
+      <Button
+        data-testid="retry-exam-button"
+        variant="primary"
+        onClick={resetExam}
+      >
+        <FormattedMessage
+          id="exam.ErrorOnboardingExamInstructions.retryExamButton"
+          defaultMessage="Retry my exam"
+        />
+      </Button>
+    </div>
+  );
+};
+
+export default ErrorPracticeExamInstructions;

--- a/src/instructions/practice_exam/SubmittedPracticeExamInstructions.jsx
+++ b/src/instructions/practice_exam/SubmittedPracticeExamInstructions.jsx
@@ -1,0 +1,39 @@
+import React, { useContext } from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Button } from '@edx/paragon';
+import ExamStateContext from '../../context';
+
+const SubmittedPracticeExamInstructions = () => {
+  const state = useContext(ExamStateContext);
+  const { resetExam } = state;
+
+  return (
+    <div>
+      <h3 className="h3" data-testid="exam-instructions-title">
+        <FormattedMessage
+          id="exam.SubmittedOnboardingExamInstructions.title"
+          defaultMessage="You have submitted this practice proctored exam"
+        />
+      </h3>
+      <p>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.text1"
+          defaultMessage={'Practice exams do not affect your grade. You have '
+          + 'completed this practice exam and can continue with your course work.'}
+        />
+      </p>
+      <Button
+        data-testid="retry-exam-button"
+        variant="primary"
+        onClick={resetExam}
+      >
+        <FormattedMessage
+          id="exam.SubmittedPracticeExamInstructions.retryExamButton"
+          defaultMessage="Retry my exam"
+        />
+      </Button>
+    </div>
+  );
+};
+
+export default SubmittedPracticeExamInstructions;

--- a/src/instructions/practice_exam/index.js
+++ b/src/instructions/practice_exam/index.js
@@ -1,1 +1,3 @@
-export { default } from './EntrancePracticeExamInstructions';
+export { default as EntrancePracticeExamInstructions } from './EntrancePracticeExamInstructions';
+export { default as ErrorPracticeExamInstructions } from './ErrorPracticeExamInstructions';
+export { default as SubmittedPracticeExamInstructions } from './SubmittedPracticeExamInstructions';

--- a/src/instructions/proctored_exam/EntranceProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/EntranceProctoredExamInstructions.jsx
@@ -8,8 +8,8 @@ import SkipProctoredExamButton from './SkipProctoredExamButton';
 
 const EntranceProctoredExamInstructions = ({ skipProctoredExam }) => {
   const state = useContext(ExamStateContext);
-  const { exam, createProctoredExamAttempt } = state;
-  const { attempt, allow_proctoring_opt_out: allowProctoringOptOut } = exam || {};
+  const { exam, createProctoredExamAttempt, allowProctoringOptOut } = state;
+  const { attempt } = exam || {};
   const { total_time: totalTime = 0 } = attempt;
 
   return (

--- a/src/instructions/proctored_exam/ErrorProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/ErrorProctoredExamInstructions.jsx
@@ -1,8 +1,7 @@
 import React, { useContext } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Container, Hyperlink, MailtoLink } from '@edx/paragon';
+import { Hyperlink, MailtoLink } from '@edx/paragon';
 import ExamStateContext from '../../context';
-import Footer from './Footer';
 
 const ErrorProctoredExamInstructions = () => {
   const state = useContext(ExamStateContext);
@@ -39,18 +38,15 @@ const ErrorProctoredExamInstructions = () => {
 
   return (
     <div>
-      <Container className="border py-5 mb-4">
-        <div className="h3">
-          <FormattedMessage
-            id="exam.ErrorProctoredExamInstructions.title"
-            defaultMessage="Error with proctored exam"
-          />
-        </div>
-        <p className="mb-0">
-          {renderBody()}
-        </p>
-      </Container>
-      <Footer />
+      <div className="h3">
+        <FormattedMessage
+          id="exam.ErrorProctoredExamInstructions.title"
+          defaultMessage="Error with proctored exam"
+        />
+      </div>
+      <p className="mb-0">
+        {renderBody()}
+      </p>
     </div>
   );
 };

--- a/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
+++ b/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
@@ -21,6 +21,7 @@ describe('SequenceExamWrapper', () => {
       examState: {
         isLoading: false,
         activeAttempt: null,
+        allowProctoringOptOut: true,
         proctoringSettings: {
           platform_name: 'Your Platform',
         },
@@ -30,7 +31,6 @@ describe('SequenceExamWrapper', () => {
         },
         exam: {
           type: ExamType.PROCTORED,
-          allow_proctoring_opt_out: true,
           is_proctored: true,
           time_limit_mins: 30,
           attempt: {},

--- a/src/instructions/proctored_exam/SubmittedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/SubmittedProctoredExamInstructions.jsx
@@ -1,51 +1,46 @@
 import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Container } from '@edx/paragon';
-import Footer from './Footer';
 
 const SubmittedProctoredExamInstructions = () => (
   <div>
-    <Container className="border py-5 mb-4">
-      <h3 className="h3" data-testid="proctored-exam-instructions-title">
+    <h3 className="h3" data-testid="proctored-exam-instructions-title">
+      <FormattedMessage
+        id="exam.SubmittedProctoredExamInstructions.title"
+        defaultMessage="You have submitted this proctored exam for review"
+      />
+    </h3>
+    <ul>
+      <li>
         <FormattedMessage
-          id="exam.SubmittedProctoredExamInstructions.title"
-          defaultMessage="You have submitted this proctored exam for review"
+          id="exam.SubmittedProctoredExamInstructions.list1"
+          defaultMessage="Your recorded data should now be uploaded for review."
         />
-      </h3>
-      <ul>
-        <li>
-          <FormattedMessage
-            id="exam.SubmittedProctoredExamInstructions.list1"
-            defaultMessage="Your recorded data should now be uploaded for review."
-          />
-          <ul>
-            <li>
-              <FormattedMessage
-                id="exam.SubmittedProctoredExamInstructions.list2"
-                defaultMessage={'If the proctoring software window is still open, close it now and '
-                + 'confirm that you want to quit the application.'}
-              />
-            </li>
-          </ul>
-        </li>
-        <li>
-          <FormattedMessage
-            id="exam.SubmittedProctoredExamInstructions.list3"
-            defaultMessage={'Proctoring results are usually available within 5 business days '
-            + 'after you submit your exam.'}
-          />
+        <ul>
+          <li>
+            <FormattedMessage
+              id="exam.SubmittedProctoredExamInstructions.list2"
+              defaultMessage={'If the proctoring software window is still open, close it now and '
+              + 'confirm that you want to quit the application.'}
+            />
+          </li>
+        </ul>
+      </li>
+      <li>
+        <FormattedMessage
+          id="exam.SubmittedProctoredExamInstructions.list3"
+          defaultMessage={'Proctoring results are usually available within 5 business days '
+          + 'after you submit your exam.'}
+        />
 
-        </li>
-      </ul>
-      <p className="mb-0">
-        <FormattedMessage
-          id="exam.SubmittedProctoredExamInstructions.text"
-          defaultMessage={'If you have questions about the status of your proctored exam results, '
-          + 'contact platform Support.'}
-        />
-      </p>
-    </Container>
-    <Footer />
+      </li>
+    </ul>
+    <p className="mb-0">
+      <FormattedMessage
+        id="exam.SubmittedProctoredExamInstructions.text"
+        defaultMessage={'If you have questions about the status of your proctored exam results, '
+        + 'contact platform Support.'}
+      />
+    </p>
   </div>
 );
 

--- a/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/VerifiedProctoredExamInstructions.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Container } from '@edx/paragon';
-import Footer from './Footer';
 
 const VerifiedProctoredExamInstructions = () => (
   <div>
-    <Container className="border py-5 mb-4 bg-success-100">
-      <h3 className="h3" data-testid="proctored-exam-instructions-title">
-        <FormattedMessage
-          id="exam.VerifiedProctoredExamInstructions.title"
-          defaultMessage={'Your proctoring session was reviewed successfully. '
-          + 'Go to your progress page to view your exam grade.'}
-        />
-      </h3>
-    </Container>
-    <Footer />
+    <h3 className="h3" data-testid="proctored-exam-instructions-title">
+      <FormattedMessage
+        id="exam.VerifiedProctoredExamInstructions.title"
+        defaultMessage={'Your proctoring session was reviewed successfully. '
+        + 'Go to your progress page to view your exam grade.'}
+      />
+    </h3>
   </div>
 );
 

--- a/src/instructions/proctored_exam/prerequisites-instructions/index.jsx
+++ b/src/instructions/proctored_exam/prerequisites-instructions/index.jsx
@@ -9,8 +9,8 @@ import Footer from '../Footer';
 
 const PrerequisitesProctoredExamInstructions = ({ skipProctoredExam }) => {
   const state = useContext(ExamStateContext);
-  const { exam, proctoringSettings } = state;
-  const { prerequisite_status: prerequisitesData, allow_proctoring_opt_out: allowProctoringOptOut } = exam;
+  const { exam, proctoringSettings, allowProctoringOptOut } = state;
+  const { prerequisite_status: prerequisitesData } = exam;
   const { pending_prerequisites: pending, failed_prerequisites: failed } = prerequisitesData;
   const { platform_name: platformName } = proctoringSettings;
 

--- a/src/instructions/timed_exam/SubmittedTimedExamInstructions.jsx
+++ b/src/instructions/timed_exam/SubmittedTimedExamInstructions.jsx
@@ -1,13 +1,12 @@
 import React, { useContext } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Container } from '@edx/paragon';
-import ExamStateContext from '../context';
+import ExamStateContext from '../../context';
 
-const SubmittedExamInstructions = () => {
+const SubmittedTimedExamInstructions = () => {
   const state = useContext(ExamStateContext);
 
   return (
-    <Container className="border py-5 mb-4">
+    <>
       <h3 className="h3" data-testid="exam.submittedExamInstructions.title">
         {state.timeIsOver
           ? (
@@ -30,8 +29,8 @@ const SubmittedExamInstructions = () => {
                 + ' but you cannot change your answers.'}
         />
       </p>
-    </Container>
+    </>
   );
 };
 
-export default SubmittedExamInstructions;
+export default SubmittedTimedExamInstructions;

--- a/src/instructions/timed_exam/index.jsx
+++ b/src/instructions/timed_exam/index.jsx
@@ -1,3 +1,4 @@
 export { default as StartTimedExamInstructions } from './StartTimedExamInstructions';
 export { default as SubmitTimedExamInstructions } from './SubmitTimedExamInstructions';
+export { default as SubmittedTimedExamInstructions } from './SubmittedTimedExamInstructions';
 export { default as TimedExamFooter } from './TimedExamFooter';


### PR DESCRIPTION
**Description**: 
Added 'allow_proctoring_opt_out' attribute for SequenceMetadata API.
Added following instruction pages:
- Error for Practice and Onboarding
- Submitted for Practice and Onboarding
- Verified for Onboarding

Removed verification check from practice and onboarding exams, check only if exam is proctored

JIRA: https://openedx.atlassian.net/browse/EDUCATOR-5808
NOTE: should be merged after #15 with https://github.com/edx/edx-platform/pull/27836 and https://github.com/edx/frontend-app-learning/pull/485