### PR TITLE
[BD-26] Redax test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21400,6 +21400,12 @@
         "inherits": "^2.0.1"
       }
     },
+    "rosie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rosie/-/rosie-2.0.1.tgz",
+      "integrity": "sha1-wlDEeHzkULcqqe/yZQn2hYmBT6I=",
+      "dev": true
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@reduxjs/toolkit": "^1.5.1",
     "reactifex": "1.1.1",
     "react-intl": "2.9.0",
-    "semantic-release": "17.2.3"
+    "semantic-release": "17.2.3",
+    "rosie": "2.0.1"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,7 @@ export const ExamStatus = Object.freeze({
   ONBOARDING_PENDING: 'onboarding_pending',
   ONBOARDING_FAILED: 'onboarding_failed',
   ONBOARDING_EXPIRED: 'onboarding_expired',
+  DECLINED: 'declined',
 });
 
 export const INCOMPLETE_STATUSES = [

--- a/src/data/__factories__/attempt.factory.js
+++ b/src/data/__factories__/attempt.factory.js
@@ -1,0 +1,19 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+Factory.define('attempt')
+  .attrs({
+    attempt_id: 1,
+    attempt_status: 'started',
+    in_timed_exam: true,
+    taking_as_proctored: false,
+    exam_type: 'a timed exam',
+    exam_display_name: 'timed',
+    exam_url_path: 'http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123',
+    time_remaining_seconds: 1799.9,
+    low_threshold_sec: 360,
+    critically_low_threshold_sec: 90,
+    course_id: 'course-v1:test+special+exam',
+    accessibility_time_string: 'you have 30 minutes remaining',
+    exam_started_poll_url: '/api/edx_proctoring/v1/proctored_exam/attempt/1',
+    desktop_application_js_url: '',
+  });

--- a/src/data/__factories__/exam.factory.js
+++ b/src/data/__factories__/exam.factory.js
@@ -1,0 +1,28 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+import './attempt.factory';
+
+Factory.define('exam')
+  .attr('attempt', {})
+  .attr('prerequisite_status', {
+    are_prerequisites_satisifed: true,
+    satisfied_prerequisites: [],
+    failed_prerequisites: [],
+    pending_prerequisites: [],
+    declined_prerequisites: [],
+  })
+  .attrs({
+    id: 1,
+    exam_name: 'prock exam',
+    course_id: 'course-v1:test+special+exam',
+    content_id: 'block-v1:test+special+exam+type@sequential+block@abc123',
+    external_id: null,
+    time_limit_mins: 30,
+    is_proctored: false,
+    is_practice_exam: false,
+    is_active: true,
+    type: 'timed',
+    due_date: null,
+    hide_after_due: false,
+    backend: 'test',
+  });

--- a/src/data/__factories__/examState.factory.js
+++ b/src/data/__factories__/examState.factory.js
@@ -1,0 +1,15 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+import './exam.factory';
+import './proctoringSettings.factory';
+
+Factory.define('examState')
+  .attr('proctoringSettings', Factory.build('proctoringSettings'))
+  .attr('exam', Factory.build('exam'))
+  .attrs({
+    isLoading: true,
+    activeAttempt: null,
+    verification: {},
+    timeIsOver: false,
+    apiErrorMsg: '',
+  });

--- a/src/data/__factories__/index.js
+++ b/src/data/__factories__/index.js
@@ -1,0 +1,4 @@
+import './examState.factory';
+import './exam.factory';
+import './attempt.factory';
+import './proctoringSettings.factory';

--- a/src/data/__factories__/proctoringSettings.factory.js
+++ b/src/data/__factories__/proctoringSettings.factory.js
@@ -1,0 +1,24 @@
+import { Factory } from 'rosie'; // eslint-disable-line import/no-extraneous-dependencies
+
+Factory.define('proctoringSettings')
+  .attrs({
+    platform_name: 'Your Platform Name Here',
+    contact_us: 'info@example.com',
+    link_urls: {
+      contact_us: 'https://example.com/contact_us/',
+      faq: 'https://example.com/faq/',
+      online_proctoring_rules: 'https://example.com/online_proctoring_rules/',
+      tech_requirements: 'https://example.com/tech_requirements/',
+    },
+    exam_proctoring_backend: {
+      download_url: '',
+      instructions: [],
+      name: '',
+      rules: {},
+    },
+    provider_tech_support_email: '',
+    provider_tech_support_phone: '',
+    provider_name: '',
+    learner_notification_from_email: '',
+    integration_specific_email: '',
+  });

--- a/src/data/__snapshots__/redux.test.jsx.snap
+++ b/src/data/__snapshots__/redux.test.jsx.snap
@@ -1,0 +1,265 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Data layer integration tests Test getExamAttemptsData Should get, and save exam and attempt 1`] = `
+Object {
+  "examState": Object {
+    "activeAttempt": Object {
+      "accessibility_time_string": "you have 30 minutes remaining",
+      "attempt_id": 1,
+      "attempt_status": "started",
+      "course_id": "course-v1:test+special+exam",
+      "critically_low_threshold_sec": 90,
+      "desktop_application_js_url": "",
+      "exam_display_name": "timed",
+      "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+      "exam_type": "a timed exam",
+      "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+      "in_timed_exam": true,
+      "low_threshold_sec": 360,
+      "taking_as_proctored": false,
+      "time_remaining_seconds": 1799.9,
+    },
+    "allowProctoringOptOut": false,
+    "apiErrorMsg": "",
+    "exam": Object {
+      "attempt": Object {
+        "accessibility_time_string": "you have 30 minutes remaining",
+        "attempt_id": 1,
+        "attempt_status": "started",
+        "course_id": "course-v1:test+special+exam",
+        "critically_low_threshold_sec": 90,
+        "desktop_application_js_url": "",
+        "exam_display_name": "timed",
+        "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+        "exam_type": "a timed exam",
+        "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+        "in_timed_exam": true,
+        "low_threshold_sec": 360,
+        "taking_as_proctored": false,
+        "time_remaining_seconds": 1799.9,
+      },
+      "backend": "test",
+      "content_id": "block-v1:test+special+exam+type@sequential+block@abc123",
+      "course_id": "course-v1:test+special+exam",
+      "due_date": null,
+      "exam_name": "prock exam",
+      "external_id": null,
+      "hide_after_due": false,
+      "id": 1,
+      "is_active": true,
+      "is_practice_exam": false,
+      "is_proctored": false,
+      "prerequisite_status": Object {
+        "are_prerequisites_satisifed": true,
+        "declined_prerequisites": Array [],
+        "failed_prerequisites": Array [],
+        "pending_prerequisites": Array [],
+        "satisfied_prerequisites": Array [],
+      },
+      "time_limit_mins": 30,
+      "type": "timed",
+    },
+    "isLoading": false,
+    "proctoringSettings": Object {
+      "contact_us": "",
+      "exam_proctoring_backend": Object {
+        "download_url": "",
+        "instructions": Array [],
+        "name": "",
+        "rules": Object {},
+      },
+      "integration_specific_email": "",
+      "learner_notification_from_email": "",
+      "link_urls": null,
+      "platform_name": "",
+      "provider_name": "",
+      "provider_tech_support_email": "",
+      "provider_tech_support_phone": "",
+    },
+    "timeIsOver": false,
+    "verification": Object {
+      "can_verify": false,
+      "expires": "",
+      "status": "",
+    },
+  },
+}
+`;
+
+exports[`Data layer integration tests Test getProctoringSettings Should fail to fetch if error occurs 1`] = `
+Object {
+  "contact_us": "",
+  "exam_proctoring_backend": Object {
+    "download_url": "",
+    "instructions": Array [],
+    "name": "",
+    "rules": Object {},
+  },
+  "integration_specific_email": "",
+  "learner_notification_from_email": "",
+  "link_urls": null,
+  "platform_name": "",
+  "provider_name": "",
+  "provider_tech_support_email": "",
+  "provider_tech_support_phone": "",
+}
+`;
+
+exports[`Data layer integration tests Test getProctoringSettings Should get, and save proctoringSettings 1`] = `
+Object {
+  "contact_us": "info@example.com",
+  "exam_proctoring_backend": Object {
+    "download_url": "",
+    "instructions": Array [],
+    "name": "",
+    "rules": Object {},
+  },
+  "integration_specific_email": "",
+  "learner_notification_from_email": "",
+  "link_urls": Object {
+    "contact_us": "https://example.com/contact_us/",
+    "faq": "https://example.com/faq/",
+    "online_proctoring_rules": "https://example.com/online_proctoring_rules/",
+    "tech_requirements": "https://example.com/tech_requirements/",
+  },
+  "platform_name": "Your Platform Name Here",
+  "provider_name": "",
+  "provider_tech_support_email": "",
+  "provider_tech_support_phone": "",
+}
+`;
+
+exports[`Data layer integration tests Test getVerificationData Should get, and save verification 1`] = `
+Object {
+  "can_verify": true,
+  "status": "none",
+}
+`;
+
+exports[`Data layer integration tests Test pollAttempt Should start exam, and update attempt and exam 1`] = `
+Object {
+  "accessibility_time_string": "you have 30 minutes remaining",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "critically_low_threshold_sec": 90,
+  "desktop_application_js_url": "",
+  "exam_display_name": "timed",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "a timed exam",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "low_threshold_sec": 360,
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
+}
+`;
+
+exports[`Data layer integration tests Test pollAttempt Should start exam, and update attempt and exam 2`] = `
+Object {
+  "accessibility_time_string": "you have 30 minutes remaining",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "critically_low_threshold_sec": 90,
+  "desktop_application_js_url": "",
+  "exam_display_name": "timed",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "a timed exam",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "low_threshold_sec": 360,
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
+}
+`;
+
+exports[`Data layer integration tests Test resetExam Should reset exam, and update attempt and exam 1`] = `
+Object {
+  "examState": Object {
+    "activeAttempt": null,
+    "allowProctoringOptOut": false,
+    "apiErrorMsg": "Request failed with status code 404",
+    "exam": Object {
+      "attempt": Object {
+        "accessibility_time_string": "you have 30 minutes remaining",
+        "attempt_id": 2,
+        "attempt_status": "created",
+        "course_id": "course-v1:test+special+exam",
+        "critically_low_threshold_sec": 90,
+        "desktop_application_js_url": "",
+        "exam_display_name": "timed",
+        "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+        "exam_type": "a timed exam",
+        "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+        "in_timed_exam": true,
+        "low_threshold_sec": 360,
+        "taking_as_proctored": false,
+        "time_remaining_seconds": 1799.9,
+      },
+      "backend": "test",
+      "content_id": "block-v1:test+special+exam+type@sequential+block@abc123",
+      "course_id": "course-v1:test+special+exam",
+      "due_date": null,
+      "exam_name": "prock exam",
+      "external_id": null,
+      "hide_after_due": false,
+      "id": 1,
+      "is_active": true,
+      "is_practice_exam": false,
+      "is_proctored": false,
+      "prerequisite_status": Object {
+        "are_prerequisites_satisifed": true,
+        "declined_prerequisites": Array [],
+        "failed_prerequisites": Array [],
+        "pending_prerequisites": Array [],
+        "satisfied_prerequisites": Array [],
+      },
+      "time_limit_mins": 30,
+      "type": "timed",
+    },
+    "isLoading": false,
+    "proctoringSettings": Object {
+      "contact_us": "",
+      "exam_proctoring_backend": Object {
+        "download_url": "",
+        "instructions": Array [],
+        "name": "",
+        "rules": Object {},
+      },
+      "integration_specific_email": "",
+      "learner_notification_from_email": "",
+      "link_urls": null,
+      "platform_name": "",
+      "provider_name": "",
+      "provider_tech_support_email": "",
+      "provider_tech_support_phone": "",
+    },
+    "timeIsOver": false,
+    "verification": Object {
+      "can_verify": false,
+      "expires": "",
+      "status": "",
+    },
+  },
+}
+`;
+
+exports[`Data layer integration tests Test startTimedExam Should start exam, and update attempt and exam 1`] = `
+Object {
+  "accessibility_time_string": "you have 30 minutes remaining",
+  "attempt_id": 1,
+  "attempt_status": "started",
+  "course_id": "course-v1:test+special+exam",
+  "critically_low_threshold_sec": 90,
+  "desktop_application_js_url": "",
+  "exam_display_name": "timed",
+  "exam_started_poll_url": "/api/edx_proctoring/v1/proctored_exam/attempt/1",
+  "exam_type": "a timed exam",
+  "exam_url_path": "http://localhost:2000/course/course-v1:test+special+exam/block-v1:test+special+exam+type@sequential+block@abc123",
+  "in_timed_exam": true,
+  "low_threshold_sec": 360,
+  "taking_as_proctored": false,
+  "time_remaining_seconds": 1799.9,
+}
+`;

--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -1,0 +1,456 @@
+import { Factory } from 'rosie';
+import MockAdapter from 'axios-mock-adapter';
+
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform';
+
+import * as thunks from './thunks';
+
+import executeThunk from '../utils';
+
+import { initializeTestStore, initializeMockApp } from '../setupTest';
+import { ExamStatus } from '../constants';
+
+const BASE_API_URL = '/api/edx_proctoring/v1/proctored_exam/attempt';
+
+const { loggingService } = initializeMockApp();
+const axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+
+describe('Data layer integration tests', () => {
+  const exam = Factory.build('exam', { attempt: Factory.build('attempt') });
+  const { course_id: courseId, content_id: contentId, attempt } = exam;
+  const fetchExamAttemptsDataUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/course_id/${courseId}/content_id/${contentId}?is_learning_mfe=true`;
+  const updateAttemptStatusUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}/${attempt.attempt_id}`;
+  let store;
+
+  beforeEach(async () => {
+    axiosMock.reset();
+    loggingService.logError.mockReset();
+    store = await initializeTestStore();
+  });
+  describe('Test getVerificationData', () => {
+    const getVerificationDataUrl = `${getConfig().LMS_BASE_URL}/verify_student/status/`;
+
+    it('Should get, and save verification', async () => {
+      axiosMock.onGet(getVerificationDataUrl).reply(200, { status: 'none', can_verify: true });
+
+      await executeThunk(thunks.getVerificationData(), store.dispatch);
+
+      const state = store.getState();
+      expect(state.examState.verification).toMatchSnapshot();
+    });
+
+    it('Should fail to fetch if error occurs', async () => {
+      axiosMock.onGet(getVerificationDataUrl).networkError();
+
+      await executeThunk(thunks.getVerificationData(), store.dispatch);
+
+      const state = store.getState();
+      expect(state.examState.apiErrorMsg).toBe('Network Error');
+    });
+  });
+
+  it('Test getAllowProctoringOptOut', async () => {
+    await executeThunk(thunks.getAllowProctoringOptOut(true), store.dispatch);
+
+    const state = store.getState();
+    expect(state.examState.allowProctoringOptOut).toEqual(true);
+  });
+
+  describe('Test getExamAttemptsData', () => {
+    it('Should get, and save exam and attempt', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+
+      const state = store.getState();
+      expect(state).toMatchSnapshot();
+    });
+
+    it('Should fail to fetch if error occurs', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).networkError();
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+
+      const state = store.getState();
+      expect(state.examState.apiErrorMsg).toBe('Network Error');
+    });
+  });
+
+  describe('Test getProctoringSettings', () => {
+    const fetchProctoringSettingsUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/settings/exam_id/${exam.id}/`;
+    const proctoringSettings = Factory.build('proctoringSettings');
+
+    it('Should get, and save proctoringSettings', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchProctoringSettingsUrl).reply(200, proctoringSettings);
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.getProctoringSettings(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(state.examState.proctoringSettings).toMatchSnapshot();
+    });
+
+    it('Should fail to fetch if error occurs', async () => {
+      axiosMock.onGet(fetchProctoringSettingsUrl).reply(200, proctoringSettings);
+
+      await executeThunk(thunks.getProctoringSettings(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.proctoringSettings).toMatchSnapshot();
+    });
+
+    it('Should fail to fetch if error occurs', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchProctoringSettingsUrl).networkError();
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.getProctoringSettings(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(state.examState.apiErrorMsg).toBe('Network Error');
+    });
+  });
+
+  describe('Test getExamReviewPolicy', () => {
+    const getExamReviewPolicyUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/proctored_exam/review_policy/exam_id/${exam.id}/`;
+    const reviewPolicy = 'Example review policy.';
+
+    it('Should get, and save getExamReviewPolicy', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(getExamReviewPolicyUrl).reply(200, { review_policy: reviewPolicy });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.getExamReviewPolicy(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(state.examState.exam.reviewPolicy).toEqual(reviewPolicy);
+    });
+
+    it('Should fail to fetch if error occurs', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(getExamReviewPolicyUrl).networkError();
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.getExamReviewPolicy(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(state.examState.apiErrorMsg).toBe('Network Error');
+    });
+
+    it('Should fail to fetch if no exam id', async () => {
+      axiosMock.onGet(getExamReviewPolicyUrl).reply(200, { review_policy: 'Example review policy.' });
+
+      await executeThunk(thunks.getExamReviewPolicy(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.exam.reviewPolicy).toBeUndefined();
+    });
+  });
+
+  describe('Test startTimedExam', () => {
+    const createExamAttemptUrl = `${getConfig().LMS_BASE_URL}${BASE_API_URL}`;
+
+    it('Should start exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: {} });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onPost(createExamAttemptUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.activeAttempt).toBeNull();
+
+      await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.activeAttempt).toMatchSnapshot();
+    });
+
+    it('Should fail to fetch if no exam id', async () => {
+      axiosMock.onPost(createExamAttemptUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+
+      await executeThunk(thunks.startTimedExam(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.apiErrorMsg).toBe('Failed to start exam. No exam id was found.');
+    });
+  });
+
+  describe('Test stopExam', () => {
+    const readyToSubmitAttempt = Factory.build('attempt', { attempt_status: ExamStatus.READY_TO_SUBMIT });
+    const readyToSubmitExam = Factory.build('exam', { attempt: readyToSubmitAttempt });
+
+    it('Should stop exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: readyToSubmitExam, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.activeAttempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.READY_TO_SUBMIT);
+    });
+
+    it('Should fail to fetch if no active attempt', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: readyToSubmitAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.stopExam(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.apiErrorMsg).toBe('Failed to stop exam. No active attempt was found.');
+    });
+  });
+
+  describe('Test continueExam', () => {
+    const readyToSubmitAttempt = Factory.build('attempt', { attempt_status: ExamStatus.READY_TO_SUBMIT });
+    const readyToSubmitExam = Factory.build('exam', { attempt: readyToSubmitAttempt });
+
+    it('Should stop exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: readyToSubmitExam, active_attempt: {} });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam, active_attempt: attempt });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.READY_TO_SUBMIT);
+
+      await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+    });
+
+    it('Should fail to fetch if no attempt id', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: attempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.apiErrorMsg).toBe('Failed to continue exam. No attempt id was found.');
+    });
+  });
+
+  describe('Test resetExam', () => {
+    const createdAttempt = Factory.build('attempt',
+      {
+        attempt_status: ExamStatus.CREATED,
+        attempt_id: 2,
+      });
+    const examWithCreatedAttempt = Factory.build('exam', { attempt: createdAttempt });
+
+    it('Should reset exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: examWithCreatedAttempt, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      await executeThunk(thunks.continueExam(), store.dispatch, store.getState);
+
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.CREATED);
+      expect(state).toMatchSnapshot();
+    });
+
+    it('Should fail to fetch if no attempt id', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.resetExam(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.apiErrorMsg).toBe('Failed to reset exam attempt. No attempt id was found.');
+    });
+  });
+
+  describe('Test submitExam', () => {
+    const submittedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.SUBMITTED });
+    const submittedExam = Factory.build('exam', { attempt: submittedAttempt });
+
+    it('Should submit exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.SUBMITTED);
+    });
+
+    it('Should fail to fetch if no attempt id', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.submitExam(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.apiErrorMsg).toBe('Failed to submit exam. No attempt id was found.');
+    });
+  });
+
+  describe('Test expireExam', () => {
+    const submittedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.SUBMITTED });
+    const submittedExam = Factory.build('exam', { attempt: submittedAttempt });
+
+    it('Should expire exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: submittedExam, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      await executeThunk(thunks.expireExam(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.SUBMITTED);
+      expect(state.examState.timeIsOver).toBe(true);
+    });
+
+    it('Should fail to fetch if no attempt id', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: submittedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.expireExam(), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(loggingService.logError).toHaveBeenCalled();
+      expect(state.examState.apiErrorMsg).toBe('Failed to expire exam. No attempt id was found.');
+    });
+  });
+
+  describe('Test startProctoringSoftwareDownload', () => {
+    const softwareDownloadedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.DOWNLOAD_SOFTWARE_CLICKED });
+    const softwareDownloadedExam = Factory.build('exam', { attempt: softwareDownloadedAttempt });
+
+    it('Should start downloading proctoring software, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: softwareDownloadedExam, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: softwareDownloadedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.STARTED);
+
+      await executeThunk(thunks.startProctoringSoftwareDownload(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DOWNLOAD_SOFTWARE_CLICKED);
+    });
+
+    it('Should fail to start if no attempt id', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: softwareDownloadedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      await executeThunk(thunks.startProctoringSoftwareDownload(), store.dispatch, store.getState);
+
+      expect(loggingService.logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test createProctoredExamAttempt', () => {
+    const createdAttempt = Factory.build('attempt', { attempt_status: ExamStatus.CREATED });
+    const createdExam = Factory.build('exam', { attempt: createdAttempt });
+
+    it('Should create exam attempt, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: createdExam, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt).toEqual({});
+
+      await executeThunk(thunks.createProctoredExamAttempt(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.CREATED);
+    });
+
+    it('Should fail to start if no attempt id', async () => {
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: createdAttempt.attempt_id });
+
+      await executeThunk(thunks.createProctoredExamAttempt(), store.dispatch, store.getState);
+
+      expect(loggingService.logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test skipProctoringExam', () => {
+    const declinedAttempt = Factory.build('attempt', { attempt_status: ExamStatus.DECLINED });
+    const declinedExam = Factory.build('exam', { attempt: declinedAttempt });
+
+    it('Should start exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam: Factory.build('exam'), active_attempt: {} });
+      axiosMock.onGet(fetchExamAttemptsDataUrl).reply(200, { exam: declinedExam, active_attempt: {} });
+      axiosMock.onPost(updateAttemptStatusUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt).toEqual({});
+
+      await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt.attempt_status).toBe(ExamStatus.DECLINED);
+    });
+
+    it('Should fail to start if no attempt id', async () => {
+      axiosMock.onGet(updateAttemptStatusUrl).reply(200, { exam_attempt_id: declinedAttempt.attempt_id });
+
+      await executeThunk(thunks.skipProctoringExam(), store.dispatch, store.getState);
+
+      expect(loggingService.logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('Test pollAttempt', () => {
+    const pollExamAttemptUrl = `${getConfig().LMS_BASE_URL}${attempt.exam_started_poll_url}`;
+    it('Should start exam, and update attempt and exam', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(pollExamAttemptUrl).reply(200, {
+        time_remaining_seconds: 1739.9,
+        accessibility_time_string: 'you have 29 minutes remaining',
+        attempt_status: ExamStatus.STARTED,
+      });
+
+      await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
+      let state = store.getState();
+      expect(state.examState.exam.attempt).toMatchSnapshot();
+
+      await executeThunk(thunks.pollAttempt(attempt.exam_started_poll_url), store.dispatch, store.getState);
+      state = store.getState();
+      expect(state.examState.exam.attempt).toMatchSnapshot();
+    });
+
+    it('Should fail to start if no attempt id', async () => {
+      axiosMock.onGet(fetchExamAttemptsDataUrl).replyOnce(200, { exam, active_attempt: attempt });
+      axiosMock.onGet(pollExamAttemptUrl).networkError();
+
+      await executeThunk(thunks.pollAttempt(attempt.exam_started_poll_url), store.dispatch, store.getState);
+
+      const state = store.getState();
+      expect(state.examState.apiErrorMsg).toBe('Network Error');
+    });
+  });
+});

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -92,7 +92,6 @@ export const examSlice = createSlice({
     expireExamAttempt: (state) => {
       state.timeIsOver = true;
     },
-    getExamId: (state) => state.examId,
     setVerificationData: (state, { payload }) => {
       state.verification = payload.verification;
     },
@@ -106,7 +105,7 @@ export const examSlice = createSlice({
 });
 
 export const {
-  setIsLoading, setExamState, getExamId, expireExamAttempt,
+  setIsLoading, setExamState, expireExamAttempt,
   setActiveAttempt, setProctoringSettings, setVerificationData,
   setReviewPolicy, setApiError, setAllowProctoringOptOut,
 } = examSlice.actions;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+// Helper, that is used to forcibly finalize all promises
+// in thunk before running matcher against state.
+const executeThunk = async (thunk, dispatch, getState) => {
+  await thunk(dispatch, getState);
+  await new Promise(setImmediate);
+};
+export default executeThunk;


### PR DESCRIPTION
Redax test coverage
Added redux tests, exam state factories, refactored initializeTestStore in setupTest.

NOTE: should be merged after https://github.com/edx/frontend-lib-special-exams/pull/21