### PR TITLE
[BD-26] Show correct allowed exam time when allowance time is added

### DIFF
--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -25,6 +25,7 @@ store.getState = () => ({
     },
     exam: {
       time_limit_mins: 30,
+      total_time: '30 minutes',
       type: 'timed',
       attempt: {},
     },
@@ -63,7 +64,7 @@ describe('SequenceExamWrapper', () => {
           can_verify: true,
         },
         exam: {
-          time_limit_mins: 30,
+          total_time: '30 minutes',
           type: 'timed',
           attempt: {},
         },

--- a/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
+++ b/src/instructions/proctored_exam/ProctoredExamInstructions.test.jsx
@@ -43,7 +43,7 @@ describe('SequenceExamWrapper', () => {
         exam: {
           type: ExamType.PROCTORED,
           is_proctored: true,
-          time_limit_mins: 30,
+          total_time: '30 minutes',
           attempt: {},
         },
       },
@@ -81,10 +81,10 @@ describe('SequenceExamWrapper', () => {
         exam: {
           type: ExamType.PROCTORED,
           is_proctored: true,
-          time_limit_mins: 30,
           attempt: {
             attempt_status: 'started',
             attempt_id: 1,
+            total_time: '30 minutes',
           },
         },
       },
@@ -118,10 +118,10 @@ describe('SequenceExamWrapper', () => {
         exam: {
           type: ExamType.PROCTORED,
           is_proctored: true,
-          time_limit_mins: 30,
           attempt: {
             attempt_status: 'ready_to_start',
             attempt_id: 1,
+            total_time: '30 minutes',
           },
         },
       },
@@ -156,10 +156,10 @@ describe('SequenceExamWrapper', () => {
         exam: {
           type: ExamType.PROCTORED,
           is_proctored: true,
-          time_limit_mins: 30,
           attempt: {
             attempt_status: 'submitted',
             attempt_id: 1,
+            total_time: '30 minutes',
           },
         },
       },

--- a/src/instructions/proctored_exam/ReadyToStartProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/ReadyToStartProctoredExamInstructions.jsx
@@ -12,7 +12,8 @@ const ReadyToStartProctoredExamInstructions = () => {
     getExamReviewPolicy,
     startProctoredExam,
   } = state;
-  const { time_limit_mins: examDuration, reviewPolicy } = exam;
+  const { attempt, reviewPolicy } = exam;
+  const { total_time: examDuration } = attempt;
   const { link_urls: linkUrls, platform_name: platformName } = proctoringSettings;
   const rulesUrl = linkUrls && linkUrls.online_proctoring_rules;
 
@@ -33,7 +34,7 @@ const ReadyToStartProctoredExamInstructions = () => {
           <li data-testid="duration-text">
             <FormattedMessage
               id="exam.ReadyToStartProctoredExamInstructions.text1"
-              defaultMessage={'You have {examDuration} minutes to complete this exam.'}
+              defaultMessage={'You have {examDuration} to complete this exam.'}
               values={{ examDuration }}
             />
           </li>

--- a/src/instructions/timed_exam/StartTimedExamInstructions.jsx
+++ b/src/instructions/timed_exam/StartTimedExamInstructions.jsx
@@ -6,14 +6,14 @@ import ExamStateContext from '../../context';
 const StartTimedExamInstructions = () => {
   const state = useContext(ExamStateContext);
   const { exam, startTimedExam } = state;
-  const examDuration = exam.time_limit_mins;
+  const examDuration = exam.total_time;
 
   return (
     <>
       <div className="h3" data-testid="exam-instructions-title">
         <FormattedMessage
           id="exam.startExamInstructions.title"
-          defaultMessage="Subsection is a Timed Exam ({examDuration} minutes)"
+          defaultMessage="Subsection is a Timed Exam ({examDuration})"
           values={{ examDuration }}
         />
       </div>
@@ -31,7 +31,7 @@ const StartTimedExamInstructions = () => {
         <FormattedMessage
           id="exam.startExamInstructions.text3"
           defaultMessage={'After you select "I am ready to start this timed exam", '
-          + 'you will have {examDuration} minutes to complete and submit the exam.'}
+          + 'you will have {examDuration} to complete and submit the exam.'}
           values={{ examDuration }}
         />
       </p>


### PR DESCRIPTION
Fix a bug where displayed total time allowed for the exam would not include allowance time.

JIRA: [EDUCATOR-5838](https://openedx.atlassian.net/browse/EDUCATOR-5838)