### PR TITLE
fix: temporarily remove end exam button when viewing non exam content

### DIFF
--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -49,6 +49,10 @@ const Exam = ({ isTimeLimited, children }) => {
 
   const sequenceContent = <>{children}</>;
 
+  // Temporary fix for CR-3842. We need to show this timer but the end exam button does not
+  // fully work yet.
+  const allowEndExam = !!examId;
+
   return (
     <div className="d-flex flex-column justify-content-center">
       {showTimer && (
@@ -58,6 +62,7 @@ const Exam = ({ isTimeLimited, children }) => {
           expireExamAttempt={expireExam}
           pollExamAttempt={pollAttempt}
           pingAttempt={pingAttempt}
+          allowEndExam={allowEndExam}
         />
       )}
       {apiErrorMsg && <ExamAPIError />}

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -124,7 +124,11 @@ ExamTimerBlock.propTypes = {
   }),
   stopExamAttempt: PropTypes.func.isRequired,
   expireExamAttempt: PropTypes.func.isRequired,
-  allowEndExam: PropTypes.bool.isRequired,
+  allowEndExam: PropTypes.bool,
+};
+
+ExamTimerBlock.defaultProps = {
+  allowEndExam: true,
 };
 
 export default ExamTimerBlock;

--- a/src/timer/ExamTimerBlock.jsx
+++ b/src/timer/ExamTimerBlock.jsx
@@ -16,7 +16,7 @@ import {
  * Exam timer block component.
  */
 const ExamTimerBlock = injectIntl(({
-  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt, intl, pingAttempt,
+  attempt, stopExamAttempt, expireExamAttempt, pollExamAttempt, intl, pingAttempt, allowEndExam,
 }) => {
   const [isShowMore, showMore, showLess] = useToggle(false);
   const [alertVariant, setAlertVariant] = useState('info');
@@ -94,6 +94,7 @@ const ExamTimerBlock = injectIntl(({
           >
 
             {attempt.attempt_status !== ExamStatus.READY_TO_SUBMIT
+              && allowEndExam
               && (
               <Button className="mr-3" variant="outline-primary" onClick={stopExamAttempt}>
                 <FormattedMessage
@@ -123,6 +124,7 @@ ExamTimerBlock.propTypes = {
   }),
   stopExamAttempt: PropTypes.func.isRequired,
   expireExamAttempt: PropTypes.func.isRequired,
+  allowEndExam: PropTypes.bool.isRequired,
 };
 
 export default ExamTimerBlock;


### PR DESCRIPTION
Fixes an oversight where you could start an exam in the legacy courseware but then enter a section in the new MFE. As a result learners are able to see our (untested/unreleased) timer component. Since the end exam button does not always work this is causing learner confusion in production. I have temporarily disabled the end exam button while we work out a formal fix.

This is actually a wider oversight because learners moving from the legacy courseware to the MFE during an exam should not have been happening in the first place. Lucky for us the timer mostly works 🎉 

https://openedx.atlassian.net/browse/CR-3842

@edx/masters-devs-cosmonauts 