### PR TITLE
[BD-26] Add handling of second review required status for proctored exams

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const ExamStatus = Object.freeze({
   STARTED: 'started',
   READY_TO_SUBMIT: 'ready_to_submit',
   SUBMITTED: 'submitted',
+  SECOND_REVIEW_REQUIRED: 'second_review_required',
   TIMED_OUT: 'timed_out',
   VERIFIED: 'verified',
   REJECTED: 'rejected',

--- a/src/exam/ExamAPIError.jsx
+++ b/src/exam/ExamAPIError.jsx
@@ -27,7 +27,7 @@ export default function ExamAPIError() {
 
     return (
       <FormattedMessage
-        id="exam.apiError.text2"
+        id="exam.defaultError"
         defaultMessage="A system error has occurred with your exam. Please reach out to support for assistance."
       />
     );

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -734,6 +734,35 @@ describe('SequenceExamWrapper', () => {
     expect(screen.getByText('You have submitted this proctored exam for review')).toBeInTheDocument();
   });
 
+  it('Shows submitted page when proctored exam is in second_review_required status', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        proctoringSettings: Factory.build('proctoringSettings', {
+          platform_name: 'Your Platform',
+        }),
+        activeAttempt: {},
+        exam: Factory.build('exam', {
+          is_proctored: true,
+          type: ExamType.PROCTORED,
+          attempt: Factory.build('attempt', {
+            attempt_status: ExamStatus.SECOND_REVIEW_REQUIRED,
+          }),
+        }),
+      }),
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText('You have submitted this proctored exam for review')).toBeInTheDocument();
+  });
+
   it('Shows download software proctored exam instructions if attempt status is created and verification status is approved', () => {
     const instructions = [
       'instruction 1',

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -812,4 +812,32 @@ describe('SequenceExamWrapper', () => {
       expect(screen.getByText(instruction)).toBeInTheDocument();
     });
   });
+
+  it('Shows error message if receives unknown attempt status', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        proctoringSettings: Factory.build('proctoringSettings', {
+          platform_name: 'Your Platform',
+        }),
+        activeAttempt: {},
+        exam: Factory.build('exam', {
+          type: ExamType.TIMED,
+          attempt: Factory.build('attempt', {
+            attempt_status: 'something new',
+          }),
+        }),
+      }),
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>children</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByTestId('unknown-status-error')).toBeInTheDocument();
+  });
 });

--- a/src/instructions/UnknownAttemptStatusError.jsx
+++ b/src/instructions/UnknownAttemptStatusError.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Alert } from '@edx/paragon';
+
+const UnknownAttemptStatusError = () => (
+  <Alert variant="danger" data-testid="unknown-status-error">
+    <Alert.Heading>
+      <FormattedMessage
+        id="exam.defaultError"
+        defaultMessage="A system error has occurred with your exam. Please reach out to support for assistance."
+      />
+    </Alert.Heading>
+  </Alert>
+);
+
+export default UnknownAttemptStatusError;

--- a/src/instructions/index.jsx
+++ b/src/instructions/index.jsx
@@ -23,6 +23,7 @@ import ErrorExamInstructions from './ErrorInstructions';
 import SubmittedExamInstructions from './SubmittedInstructions';
 import VerifiedExamInstructions from './VerifiedInstructions';
 import ExpiredInstructions from './ExpiredInstructions';
+import UnknownAttemptStatusError from './UnknownAttemptStatusError';
 
 const Instructions = ({ children }) => {
   const state = useContext(ExamStateContext);
@@ -75,10 +76,13 @@ const Instructions = ({ children }) => {
       return <ReadyToStartProctoredExamInstructions />;
     case attemptStatus === ExamStatus.READY_TO_SUBMIT:
       return <SubmitExamInstructions />;
-    // don't show submitted page for timed exam if exam has passed due date
-    // and in studio visibility option is set to 'show entire section'
-    // instead show exam content
-    case attemptStatus === ExamStatus.SUBMITTED && !(examType === ExamType.TIMED && passedDueDate && !hideAfterDue):
+    case attemptStatus === ExamStatus.SUBMITTED:
+      // don't show submitted page for timed exam if exam has passed due date
+      // and in studio visibility option is set to 'show entire section'
+      // instead show exam content
+      if (examType === ExamType.TIMED && passedDueDate && !hideAfterDue) {
+        return children;
+      }
       return <SubmittedExamInstructions examType={examType} />;
     case attemptStatus === ExamStatus.SECOND_REVIEW_REQUIRED:
       return <SubmittedExamInstructions examType={examType} />;
@@ -92,8 +96,10 @@ const Instructions = ({ children }) => {
       return <EntranceExamInstructions examType={examType} skipProctoredExam={toggleSkipProctoredExam} />;
     case examType === ExamType.PROCTORED && IS_ONBOARDING_ERROR(attemptStatus):
       return <OnboardingErrorProctoredExamInstructions />;
-    default:
+    case attemptStatus === ExamStatus.STARTED:
       return children;
+    default:
+      return <UnknownAttemptStatusError />;
   }
 };
 

--- a/src/instructions/index.jsx
+++ b/src/instructions/index.jsx
@@ -80,6 +80,8 @@ const Instructions = ({ children }) => {
     // instead show exam content
     case attemptStatus === ExamStatus.SUBMITTED && !(examType === ExamType.TIMED && passedDueDate && !hideAfterDue):
       return <SubmittedExamInstructions examType={examType} />;
+    case attemptStatus === ExamStatus.SECOND_REVIEW_REQUIRED:
+      return <SubmittedExamInstructions examType={examType} />;
     case attemptStatus === ExamStatus.VERIFIED:
       return <VerifiedExamInstructions examType={examType} />;
     case attemptStatus === ExamStatus.REJECTED:


### PR DESCRIPTION
Fix missing second_review_required status for proctored exams, which resulted in showing exam content to the student

JIRA: [EDUCATOR-5909](https://openedx.atlassian.net/browse/EDUCATOR-5909)