### PR TITLE
fix: display exam content for masquerading user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-lib-special-exams",
-  "version": "1.0.0",
+  "version": "1.13.0",
   "description": "Special exams lib",
   "main": "dist/index.js",
   "release": {

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -10,7 +10,12 @@ import ExamStateContext from '../context';
 const ExamWrapper = ({ children, ...props }) => {
   const state = useContext(ExamStateContext);
   const { authenticatedUser } = useContext(AppContext);
-  const { sequence, courseId, isStaff } = props;
+  const {
+    sequence,
+    courseId,
+    isStaff,
+    originalUserIsStaff,
+  } = props;
   const { getExamAttemptsData, getAllowProctoringOptOut } = state;
   const loadInitialData = async () => {
     await getExamAttemptsData(courseId, sequence.id);
@@ -29,7 +34,7 @@ const ExamWrapper = ({ children, ...props }) => {
   }, []);
 
   return (
-    <Exam isTimeLimited={sequence.isTimeLimited}>
+    <Exam isTimeLimited={sequence.isTimeLimited} originalUserIsStaff={originalUserIsStaff}>
       {children}
     </Exam>
   );
@@ -44,10 +49,12 @@ ExamWrapper.propTypes = {
   courseId: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
   isStaff: PropTypes.bool,
+  originalUserIsStaff: PropTypes.bool,
 };
 
 ExamWrapper.defaultProps = {
   isStaff: false,
+  originalUserIsStaff: false,
 };
 
 export default ExamWrapper;


### PR DESCRIPTION
[MST-944](https://openedx.atlassian.net/browse/MST-944)

If a staff user is masquerading as a specific learner, they should be able to view exam content regardless of the learner's state. If the learner would not normally be able to see the exam content, an alert with this information will display for the masquerading user.

Related PRs:
https://github.com/edx/edx-platform/pull/28458
https://github.com/edx/frontend-app-learning/pull/610

---

### Staff view:
![Screen Shot 2021-08-23 at 1 18 06 PM](https://user-images.githubusercontent.com/10442143/130490442-3afc025c-0cf3-4089-b743-6ff0bd4f199a.png)

---

### Learner view:
![Screen Shot 2021-08-23 at 1 24 26 PM](https://user-images.githubusercontent.com/10442143/130490457-0bc2e7b3-2f7b-4501-9d1a-b0a16e1e3df6.png)
