### PR TITLE
feat: support for content gating

### DIFF
--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -18,7 +18,9 @@ import { ExamStatus, ExamType } from '../constants';
  * @returns {JSX.Element}
  * @constructor
  */
-const Exam = ({ isTimeLimited, originalUserIsStaff, children }) => {
+const Exam = ({
+  isGated, isTimeLimited, originalUserIsStaff, children,
+}) => {
   const state = useContext(ExamStateContext);
   const {
     isLoading, activeAttempt, showTimer, stopExam, exam,
@@ -93,7 +95,7 @@ const Exam = ({ isTimeLimited, originalUserIsStaff, children }) => {
         />
       )}
       {apiErrorMsg && <ExamAPIError />}
-      {isTimeLimited && !originalUserIsStaff
+      {isTimeLimited && !originalUserIsStaff && !isGated
         ? <Instructions>{sequenceContent}</Instructions>
         : sequenceContent}
     </div>
@@ -102,6 +104,7 @@ const Exam = ({ isTimeLimited, originalUserIsStaff, children }) => {
 
 Exam.propTypes = {
   isTimeLimited: PropTypes.bool.isRequired,
+  isGated: PropTypes.bool.isRequired,
   originalUserIsStaff: PropTypes.bool.isRequired,
   children: PropTypes.element.isRequired,
 };

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -22,6 +22,8 @@ const ExamWrapper = ({ children, ...props }) => {
     await getAllowProctoringOptOut(sequence.allowProctoringOptOut);
   };
 
+  const isGated = sequence && sequence.gatedContent !== undefined && sequence.gatedContent.gated;
+
   // if the user is browsing public content (not logged in) they cannot be in an exam
   // if the user is staff they may view exam content without an exam attempt
   // any requests for exam state will 403 so just short circuit this component here
@@ -34,7 +36,7 @@ const ExamWrapper = ({ children, ...props }) => {
   }, []);
 
   return (
-    <Exam isTimeLimited={sequence.isTimeLimited} originalUserIsStaff={originalUserIsStaff}>
+    <Exam isGated={isGated} isTimeLimited={sequence.isTimeLimited} originalUserIsStaff={originalUserIsStaff}>
       {children}
     </Exam>
   );
@@ -45,6 +47,9 @@ ExamWrapper.propTypes = {
     id: PropTypes.string.isRequired,
     isTimeLimited: PropTypes.bool,
     allowProctoringOptOut: PropTypes.bool,
+    gatedContent: PropTypes.shape({
+      gated: PropTypes.bool,
+    }),
   }).isRequired,
   courseId: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,

--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -163,6 +163,28 @@ describe('SequenceExamWrapper', () => {
     expect(queryByTestId('masquerade-alert')).toBeInTheDocument();
   });
 
+  it('allows default content rendering for gated sections even for exams', () => {
+    sequence.gatedContent = {
+      gated: true,
+    };
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        exam: Factory.build('exam', {
+          type: ExamType.PROCTORED,
+        }),
+      }),
+    });
+    const { queryByTestId } = render(
+      <ExamStateProvider>
+        <SequenceExamWrapper sequence={sequence} courseId={courseId}>
+          <div data-testid="sequence-content">children</div>
+        </SequenceExamWrapper>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(queryByTestId('sequence-content')).toHaveTextContent('children');
+  });
+
   it('does not display masquerade alert if specified learner is in the middle of the exam', () => {
     store.getState = () => ({
       examState: Factory.build('examState', {

--- a/src/instructions/proctored_exam/download-instructions/DefaultInstructions.jsx
+++ b/src/instructions/proctored_exam/download-instructions/DefaultInstructions.jsx
@@ -11,9 +11,9 @@ const DefaultInstructions = ({ code }) => (
         defaultMessage="Step 1."
       />
     </div>
-    <p>
+    <div>
       <ExamCode code={code} />
-    </p>
+    </div>
     <p>
       <FormattedMessage
         id="exam.DefaultDownloadSoftwareProctoredExamInstructions.step1.body"

--- a/src/instructions/proctored_exam/download-instructions/index.jsx
+++ b/src/instructions/proctored_exam/download-instructions/index.jsx
@@ -105,7 +105,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
           downloadClicked={downloadClicked}
         />
         {!withProviderInstructions && (
-          <p className="pt-3">
+          <div className="pt-3">
             <div className="h4">
               <FormattedMessage
                 id="exam.DefaultDownloadSoftwareProctoredExamInstructions.step3.title"
@@ -120,7 +120,7 @@ const DownloadSoftwareProctoredExamInstructions = ({ intl, skipProctoredExam }) 
                 + 'direct you to the RPNow proctoring experience.'}
               />
             </p>
-          </p>
+          </div>
         )}
       </Container>
       {allowProctoringOptOut && <SkipProctoredExamButton handleClick={skipProctoredExam} />}


### PR DESCRIPTION
### [MST-991](https://openedx.atlassian.net/browse/MST-991)

Handle content gating by allowing default learning MFE rendering instead of exam interstitials for sections that are locked. Note this behavior is distinctly different from the exam prerequisite views which are based solely on CreditRequirements. In the case both are not satisfied the effect of this PR is that content gating would take precedence. This is how the old LMS views currently work.

Bonus: Fixed some HTML validation that was barfing errors into the test console

@edx/masters-devs-cosmonauts 