### PR TITLE
fix: only show masquerade message for time gated content

### DIFF
--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -38,7 +38,7 @@ const Exam = ({ isTimeLimited, originalUserIsStaff, children }) => {
   const shouldShowMasqueradeAlert = () => {
     // if course staff is masquerading as a specific learner, they should be able
     // to view the exam content regardless of the learner's current state
-    if (originalUserIsStaff) {
+    if (originalUserIsStaff && isTimeLimited) {
       if (examType === ExamType.TIMED && passedDueDate && !hideAfterDue) {
         // if the learner is able to view exam content after the due date is passed,
         // don't show this alert

--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -212,4 +212,17 @@ describe('SequenceExamWrapper', () => {
     expect(queryByTestId('sequence-content')).toHaveTextContent('children');
     expect(queryByTestId('masquerade-alert')).not.toBeInTheDocument();
   });
+
+  it('does not display masquerade alert if sequence is not time gated', () => {
+    const { queryByTestId } = render(
+      <ExamStateProvider>
+        <SequenceExamWrapper sequence={{ ...sequence, isTimeLimited: false }} courseId={courseId} originalUserIsStaff>
+          <div data-testid="sequence-content">children</div>
+        </SequenceExamWrapper>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(queryByTestId('sequence-content')).toHaveTextContent('children');
+    expect(queryByTestId('masquerade-alert')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## [MST-1012](https://openedx.atlassian.net/browse/MST-1012)

The masquerading message for exams should only be shown if content is time gated, in addition to the other conditionals that were previously in place.