### PR TITLE
fix: default branch is not "master"

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,8 +2,3 @@
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
 oeps: {}
-openedx-release:
-  # The openedx-release key is described in OEP-10:
-  #   https://open-edx-proposals.readthedocs.io/en/latest/oep-0010-proc-openedx-releases.html
-  # The FAQ might also be helpful: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1331268879/Open+edX+Release+FAQ
-  ref: master


### PR DESCRIPTION
During the release process, the tag_release scripts crashes with:

```
Traceback (most recent call last):
  File "/home/data/regis/projets/openedx/repos/repo-tools/.venv/bin/tag_release", line 33, in <module>
    sys.exit(load_entry_point('edx-repo-tools', 'console_scripts', 'tag_release')())
  File "/home/data/regis/projets/openedx/repos/repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/data/regis/projets/openedx/repos/repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/data/regis/projets/openedx/repos/repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/data/regis/projets/openedx/repos/repo-tools/.venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/data/regis/projets/openedx/repos/repo-tools/edx_repo_tools/auth.py", line 224, in wrapped
  File "/home/data/regis/projets/openedx/repos/repo-tools/edx_repo_tools/release/tag_release.py", line 714, in main
    ret = do_the_work(repos, ref, use_tag, reverse, skip_invalid, interactive, quiet, dry)
  File "/home/data/regis/projets/openedx/repos/repo-tools/edx_repo_tools/release/tag_release.py", line 768, in do_the_work
    ref_info = commit_ref_info(repos, skip_invalid=skip_invalid)
  File "/home/data/regis/projets/openedx/repos/repo-tools/edx_repo_tools/release/tag_release.py", line 216, in commit_ref_info
    ref_info[repo] = get_latest_commit_for_ref(repo, ref)
  File "/home/data/regis/projets/openedx/repos/repo-tools/edx_repo_tools/release/tag_release.py", line 276, in get_latest_commit_for_ref
    raise ValueError(f"In repo {repo}, ref {ref!r} doesn't exist.")
ValueError: In repo edx/frontend-lib-special-exams, ref 'master' doesn't exist.
```

Actually, the repo should not even be released, so should not have an openedx.yaml file.
