### PR TITLE
fix: exam attempts marked as ready to resume should remain resumable

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -12,7 +12,6 @@ export const ExamStatus = Object.freeze({
   VERIFIED: 'verified',
   REJECTED: 'rejected',
   ERROR: 'error',
-  READY_TO_RESUME: 'ready_to_resume',
   ONBOARDING_MISSING: 'onboarding_missing',
   ONBOARDING_PENDING: 'onboarding_pending',
   ONBOARDING_FAILED: 'onboarding_failed',

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -247,7 +247,7 @@ describe('SequenceExamWrapper', () => {
     expect(screen.getByText('Error with proctored exam')).toBeInTheDocument();
   });
 
-  it('Instructions for ready to resume status', () => {
+  it('Instructions for ready to resume state', () => {
     store.getState = () => ({
       examState: Factory.build('examState', {
         timeIsOver: true,
@@ -257,7 +257,8 @@ describe('SequenceExamWrapper', () => {
         exam: Factory.build('exam', {
           type: ExamType.PROCTORED,
           attempt: Factory.build('attempt', {
-            attempt_status: ExamStatus.READY_TO_RESUME,
+            attempt_status: ExamStatus.ERROR,
+            attempt_ready_to_resume: true,
           }),
         }),
       }),

--- a/src/instructions/index.jsx
+++ b/src/instructions/index.jsx
@@ -37,7 +37,11 @@ const Instructions = ({ children }) => {
   } = exam || {};
   const prerequisitesPassed = prerequisitesData ? prerequisitesData.are_prerequisites_satisifed : true;
   let verificationStatus = verification.status || '';
-  const { verification_url: verificationUrl, attempt_status: attemptStatus } = attempt || {};
+  const {
+    verification_url: verificationUrl,
+    attempt_status: attemptStatus,
+    attempt_ready_to_resume: attemptReadyToResume,
+  } = attempt || {};
   const [skipProctoring, toggleSkipProctoring] = useState(false);
   const toggleSkipProctoredExam = () => toggleSkipProctoring(!skipProctoring);
   const expired = shouldRenderExpiredPage(exam);
@@ -66,6 +70,8 @@ const Instructions = ({ children }) => {
       return <SkipProctoredExamInstruction cancelSkipProctoredExam={toggleSkipProctoredExam} />;
     case isEmpty(attempt) || !attempt.attempt_id:
       return renderEmptyAttemptInstructions();
+    case attemptReadyToResume:
+      return <EntranceExamInstructions examType={examType} skipProctoredExam={toggleSkipProctoredExam} />;
     case attemptStatus === ExamStatus.CREATED:
       return examType === ExamType.PROCTORED && verificationStatus !== VerificationStatus.APPROVED
         ? <VerificationProctoredExamInstructions status={verificationStatus} verificationUrl={verificationUrl} />
@@ -92,8 +98,6 @@ const Instructions = ({ children }) => {
       return <RejectedInstructions examType={examType} />;
     case attemptStatus === ExamStatus.ERROR:
       return <ErrorExamInstructions examType={examType} />;
-    case attemptStatus === ExamStatus.READY_TO_RESUME:
-      return <EntranceExamInstructions examType={examType} skipProctoredExam={toggleSkipProctoredExam} />;
     case examType === ExamType.PROCTORED && IS_ONBOARDING_ERROR(attemptStatus):
       return <OnboardingErrorProctoredExamInstructions />;
     case attemptStatus === ExamStatus.STARTED:

--- a/src/instructions/proctored_exam/EntranceProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/EntranceProctoredExamInstructions.jsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { Button } from '@edx/paragon';
-import { ExamStatus } from '../../constants';
 import ExamStateContext from '../../context';
 import SkipProctoredExamButton from './SkipProctoredExamButton';
 
@@ -14,7 +13,7 @@ const EntranceProctoredExamInstructions = ({ skipProctoredExam }) => {
 
   return (
     <>
-      { attempt.attempt_status === ExamStatus.READY_TO_RESUME ? (
+      { attempt.attempt_ready_to_resume ? (
         <div>
           <div className="h3" data-testid="proctored-exam-instructions-title">
             <FormattedMessage


### PR DESCRIPTION
## [MST-1124](https://openedx.atlassian.net/browse/MST-1124)

Exam attempts that have been marked as ready to resume should remain resumable, even if they receive a review. This PR is the frontend portion to the changes made [to the backend](https://github.com/edx/edx-proctoring/pull/985), which transition the states of resuming from being represented as a status to being represented as a boolean field. As such, is is now possible for exam attempts to have an `error`, or any reviewed status, and also be marked as ready to resume. If the exam has been marked as ready to resume, we should prioritize that state over the current status.