### PR TITLE
[MST-1150] Don't show IDV interstitial if IDV is disabled for the course

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-lib-special-exams",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-lib-special-exams",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Special exams lib",
   "main": "dist/index.js",
   "release": {

--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -19,7 +19,7 @@ import { ExamStatus, ExamType } from '../constants';
  * @constructor
  */
 const Exam = ({
-  isGated, isTimeLimited, originalUserIsStaff, children,
+  isGated, isTimeLimited, originalUserIsStaff, isIntegritySignatureEnabled, children,
 }) => {
   const state = useContext(ExamStateContext);
   const {
@@ -98,7 +98,7 @@ const Exam = ({
         isTimeLimited && apiErrorMsg && <ExamAPIError />
       }
       {isTimeLimited && !originalUserIsStaff && !isGated
-        ? <Instructions>{sequenceContent}</Instructions>
+        ? <Instructions isIntegritySignatureEnabled={isIntegritySignatureEnabled}>{sequenceContent}</Instructions>
         : sequenceContent}
     </div>
   );
@@ -108,7 +108,12 @@ Exam.propTypes = {
   isTimeLimited: PropTypes.bool.isRequired,
   isGated: PropTypes.bool.isRequired,
   originalUserIsStaff: PropTypes.bool.isRequired,
+  isIntegritySignatureEnabled: PropTypes.bool,
   children: PropTypes.element.isRequired,
+};
+
+Exam.defaultProps = {
+  isIntegritySignatureEnabled: false,
 };
 
 export default Exam;

--- a/src/exam/ExamWrapper.jsx
+++ b/src/exam/ExamWrapper.jsx
@@ -15,6 +15,7 @@ const ExamWrapper = ({ children, ...props }) => {
     courseId,
     isStaff,
     originalUserIsStaff,
+    isIntegritySignatureEnabled,
   } = props;
   const { getExamAttemptsData, getAllowProctoringOptOut } = state;
   const loadInitialData = async () => {
@@ -36,7 +37,12 @@ const ExamWrapper = ({ children, ...props }) => {
   }, []);
 
   return (
-    <Exam isGated={isGated} isTimeLimited={sequence.isTimeLimited} originalUserIsStaff={originalUserIsStaff}>
+    <Exam
+      isGated={isGated}
+      isTimeLimited={sequence.isTimeLimited}
+      originalUserIsStaff={originalUserIsStaff}
+      isIntegritySignatureEnabled={isIntegritySignatureEnabled}
+    >
       {children}
     </Exam>
   );
@@ -55,11 +61,13 @@ ExamWrapper.propTypes = {
   children: PropTypes.element.isRequired,
   isStaff: PropTypes.bool,
   originalUserIsStaff: PropTypes.bool,
+  isIntegritySignatureEnabled: PropTypes.bool,
 };
 
 ExamWrapper.defaultProps = {
   isStaff: false,
   originalUserIsStaff: false,
+  isIntegritySignatureEnabled: false,
 };
 
 export default ExamWrapper;

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -814,6 +814,56 @@ describe('SequenceExamWrapper', () => {
     });
   });
 
+  it('Shows download software proctored exam instructions verification is not approved, but integrity signature flag is turned on', () => {
+    const instructions = [
+      'instruction 1',
+      'instruction 2',
+      'instruction 3',
+    ];
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        activeAttempt: {},
+        proctoringSettings: Factory.build('proctoringSettings', {
+          provider_name: 'Provider Name',
+          provider_tech_support_email: 'support@example.com',
+          provider_tech_support_phone: '+123456789',
+          exam_proctoring_backend: {
+            instructions,
+          },
+        }),
+        verification: {
+          status: VerificationStatus.NONE,
+          can_verify: true,
+        },
+        exam: Factory.build('exam', {
+          is_proctored: true,
+          type: ExamType.PROCTORED,
+          attempt: Factory.build('attempt', {
+            attempt_status: ExamStatus.CREATED,
+          }),
+        }),
+      }),
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions isIntegritySignatureEnabled>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText(
+      'If you have issues relating to proctoring, you can contact '
+      + 'Provider Name technical support by emailing support@example.com or by calling +123456789.',
+    )).toBeInTheDocument();
+    expect(screen.getByText('Set up and start your proctored exam.')).toBeInTheDocument();
+    instructions.forEach((instruction) => {
+      expect(screen.getByText(instruction)).toBeInTheDocument();
+    });
+  });
+
   it('Shows error message if receives unknown attempt status', () => {
     store.getState = () => ({
       examState: Factory.build('examState', {

--- a/src/instructions/index.jsx
+++ b/src/instructions/index.jsx
@@ -25,7 +25,7 @@ import VerifiedExamInstructions from './VerifiedInstructions';
 import ExpiredInstructions from './ExpiredInstructions';
 import UnknownAttemptStatusError from './UnknownAttemptStatusError';
 
-const Instructions = ({ children }) => {
+const Instructions = ({ isIntegritySignatureEnabled, children }) => {
   const state = useContext(ExamStateContext);
   const { exam, verification } = state;
   const {
@@ -58,6 +58,8 @@ const Instructions = ({ children }) => {
     return component;
   };
 
+  const blockedByIdv = () => !isIntegritySignatureEnabled && verificationStatus !== VerificationStatus.APPROVED;
+
   // The API does not explicitly return 'expired' status, so we have to check manually.
   // expires attribute is returned only for approved status, so it is safe to do this
   // (meaning we won't override 'must_reverify' status for example)
@@ -73,7 +75,7 @@ const Instructions = ({ children }) => {
     case attemptReadyToResume:
       return <EntranceExamInstructions examType={examType} skipProctoredExam={toggleSkipProctoredExam} />;
     case attemptStatus === ExamStatus.CREATED:
-      return examType === ExamType.PROCTORED && verificationStatus !== VerificationStatus.APPROVED
+      return examType === ExamType.PROCTORED && blockedByIdv()
         ? <VerificationProctoredExamInstructions status={verificationStatus} verificationUrl={verificationUrl} />
         : <DownloadSoftwareProctoredExamInstructions skipProctoredExam={toggleSkipProctoredExam} />;
     case attemptStatus === ExamStatus.DOWNLOAD_SOFTWARE_CLICKED:
@@ -109,6 +111,11 @@ const Instructions = ({ children }) => {
 
 Instructions.propTypes = {
   children: PropTypes.element.isRequired,
+  isIntegritySignatureEnabled: PropTypes.bool,
+};
+
+Instructions.defaultProps = {
+  isIntegritySignatureEnabled: false,
 };
 
 export default Instructions;


### PR DESCRIPTION
[MST-1150](https://openedx.atlassian.net/browse/MST-1150)

IDV is considered disabled for a course if the integrity signature flag is enabled. If this flag is turned on, do not block the learner from taking proctored exams if they do not have approved ID verification.