### PR TITLE
Improve Exam Start Failure

### DIFF
--- a/src/data/redux.test.jsx
+++ b/src/data/redux.test.jsx
@@ -546,7 +546,7 @@ describe('Data layer integration tests', () => {
 
       await executeThunk(thunks.getExamAttemptsData(courseId, contentId), store.dispatch);
       await executeThunk(thunks.startProctoredExam(), store.dispatch, store.getState);
-      expect(loggingService.logInfo).toHaveBeenCalledWith(
+      expect(loggingService.logError).toHaveBeenCalledWith(
         Error('test error'), {
           attemptId: createdWorkerAttempt.attempt_id,
           courseId: createdWorkerAttempt.course_id,

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -146,10 +146,12 @@ export function startProctoredExam() {
     const useWorker = window.Worker && workerUrl;
 
     if (useWorker) {
-      workerPromiseForEventNames(actionToMessageTypesMap.start, exam.attempt.desktop_application_js_url)()
-        .then(() => updateAttemptAfter(
-          exam.course_id, exam.content_id, continueAttempt(attempt.attempt_id),
-        )(dispatch))
+      const startExamTimeoutMilliseconds = 2000;
+      workerPromiseForEventNames(actionToMessageTypesMap.start, exam.attempt.desktop_application_js_url)(
+        startExamTimeoutMilliseconds,
+      ).then(() => updateAttemptAfter(
+        exam.course_id, exam.content_id, continueAttempt(attempt.attempt_id),
+      )(dispatch))
         .catch(error => {
           if (error) {
             logInfo(

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -1,4 +1,4 @@
-import { logError, logInfo } from '@edx/frontend-platform/logging';
+import { logError } from '@edx/frontend-platform/logging';
 import {
   fetchExamAttemptsData,
   createExamAttempt,
@@ -154,7 +154,7 @@ export function startProctoredExam() {
       )(dispatch))
         .catch(error => {
           if (error) {
-            logInfo(
+            logError(
               error,
               {
                 attemptId: attempt.attempt_id,
@@ -383,6 +383,14 @@ export function pingAttempt(timeoutInSeconds, workerUrl) {
       .catch(async (error) => {
         const { exam, activeAttempt } = getState().examState;
         const message = error ? error.message : 'Worker failed to respond.';
+        logError(
+          message,
+          {
+            attemptId: activeAttempt.attempt_id,
+            courseId: activeAttempt.course_id,
+            examId: activeAttempt.exam.id,
+          },
+        );
         await updateAttemptAfter(
           exam.course_id, exam.content_id, endExamWithFailure(activeAttempt.attempt_id, message),
         )(dispatch);

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -35,6 +35,8 @@ function handleAPIError(error, dispatch) {
   dispatch(setApiError({ errorMsg: message || detail }));
 }
 
+const EXAM_START_TIMEOUT_MILLISECONDS = 5000;
+
 /**
  * Fetch attempt data and update exam state after performing another action if it is provided.
  * It is assumed that action somehow modifies attempt in the backend, that's why the state needs
@@ -146,7 +148,7 @@ export function startProctoredExam() {
     const useWorker = window.Worker && workerUrl;
 
     if (useWorker) {
-      const startExamTimeoutMilliseconds = 2000;
+      const startExamTimeoutMilliseconds = EXAM_START_TIMEOUT_MILLISECONDS;
       workerPromiseForEventNames(actionToMessageTypesMap.start, exam.attempt.desktop_application_js_url)(
         startExamTimeoutMilliseconds,
       ).then(() => updateAttemptAfter(

--- a/src/instructions/Instructions.test.jsx
+++ b/src/instructions/Instructions.test.jsx
@@ -891,4 +891,64 @@ describe('SequenceExamWrapper', () => {
 
     expect(screen.getByTestId('unknown-status-error')).toBeInTheDocument();
   });
+
+  it('Shows ready to start page when proctored exam is in ready_to_start status', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        proctoringSettings: Factory.build('proctoringSettings', {
+          platform_name: 'Your Platform',
+        }),
+        activeAttempt: {},
+        exam: Factory.build('exam', {
+          is_proctored: true,
+          type: ExamType.PROCTORED,
+          attempt: Factory.build('attempt', {
+            attempt_status: ExamStatus.READY_TO_START,
+          }),
+        }),
+      }),
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(screen.getByText('You must adhere to the following rules while you complete this exam.')).toBeInTheDocument();
+  });
+
+  it('Shows loading spinner while waiting to start exam', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        proctoringSettings: Factory.build('proctoringSettings', {
+          platform_name: 'Your Platform',
+        }),
+        activeAttempt: {},
+        exam: Factory.build('exam', {
+          is_proctored: true,
+          type: ExamType.PROCTORED,
+          attempt: Factory.build('attempt', {
+            attempt_status: ExamStatus.READY_TO_START,
+          }),
+        }),
+        startProctoredExam: jest.fn(),
+      }),
+    });
+
+    render(
+      <ExamStateProvider>
+        <Instructions>
+          <div>Sequence</div>
+        </Instructions>
+      </ExamStateProvider>,
+      { store },
+    );
+
+    fireEvent.click(screen.getByTestId('start-exam-button'));
+    expect(screen.getByTestId('exam-loading-spinner')).toBeInTheDocument();
+  });
 });

--- a/src/instructions/proctored_exam/ReadyToStartProctoredExamInstructions.jsx
+++ b/src/instructions/proctored_exam/ReadyToStartProctoredExamInstructions.jsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Button, Container } from '@edx/paragon';
+import { Button, Container, Spinner } from '@edx/paragon';
 import ExamStateContext from '../../context';
 import Footer from './Footer';
 
@@ -16,10 +16,16 @@ const ReadyToStartProctoredExamInstructions = () => {
   const { total_time: examDuration } = attempt;
   const { link_urls: linkUrls, platform_name: platformName } = proctoringSettings;
   const rulesUrl = linkUrls && linkUrls.online_proctoring_rules;
+  const [beginExamClicked, setBeginExamClicked] = useState(false);
 
   useEffect(() => {
     getExamReviewPolicy();
   }, []);
+
+  const handleStart = () => {
+    setBeginExamClicked(true);
+    startProctoredExam();
+  };
 
   return (
     <div>
@@ -113,8 +119,10 @@ const ReadyToStartProctoredExamInstructions = () => {
         <Button
           data-testid="start-exam-button"
           variant="primary"
-          onClick={startProctoredExam}
+          onClick={handleStart}
+          disabled={beginExamClicked}
         >
+          { beginExamClicked && <Spinner data-testid="exam-loading-spinner" animation="border" /> }
           <FormattedMessage
             id="exam.startExamInstructions.startExamButtonText"
             defaultMessage="Start exam"


### PR DESCRIPTION
1. The application will now wait 5 seconds to connect with the Proctortrack application before showing an error. This previously took two minutes with no user feedback what was happening.  Under the hood this will retry five times still.
2. Added a spinner to the button while this is taking place
3. Changed to the log level for these errors from info to error. Info messages don't seem to be getting logged, not sure why. Either way this should have no significant impact on error rates as we receive up to 600/hr for translation errors alone.

Note: This can be merged, but the timeout will still be two minutes until https://github.com/anupdhabarde/edx-proctoring-proctortrack/pull/19 is also merged

@edx/masters-devs-cosmonauts 

[MST-1252](https://openedx.atlassian.net/browse/MST-1252)

![Screen Shot 2021-12-22 at 11 26 13 AM](https://user-images.githubusercontent.com/5661461/147124097-82f5409d-5346-4c57-83c6-52502b63ef6d.png)

