### PR TITLE
[MST-1266] Improve API error messaging

### DIFF
--- a/src/exam/ExamAPIError.test.jsx
+++ b/src/exam/ExamAPIError.test.jsx
@@ -1,9 +1,17 @@
 import '@testing-library/jest-dom';
 import React from 'react';
+import { getConfig } from '@edx/frontend-platform';
 import { store } from '../data';
-import { render, fireEvent } from '../setupTest';
+import { render } from '../setupTest';
 import ExamStateProvider from '../core/ExamStateProvider';
 import ExamAPIError from './ExamAPIError';
+
+const originalConfig = jest.requireActual('@edx/frontend-platform').getConfig();
+jest.mock('@edx/frontend-platform', () => ({
+  ...jest.requireActual('@edx/frontend-platform'),
+  getConfig: jest.fn(),
+}));
+getConfig.mockImplementation(() => originalConfig);
 
 jest.mock('../data', () => ({
   store: {},
@@ -11,57 +19,46 @@ jest.mock('../data', () => ({
 store.subscribe = jest.fn();
 store.dispatch = jest.fn();
 
-describe('ExamAPiError', () => {
-  it('shows heading with platform contact info if is is provided', () => {
-    store.getState = () => ({
-      examState: {
-        apiErrorMsg: 'Something bad has happened',
-        proctoringSettings: {
-          contact_us: 'https://example.com',
-          platform_name: 'Your Platform Name',
-        },
-      },
-    });
+describe('ExamAPIError', () => {
+  const defaultMessage = 'A system error has occurred with your exam.';
 
-    const { queryByTestId } = render(
+  it('renders with the default information', () => {
+    store.getState = () => ({ examState: {} });
+
+    const tree = render(
       <ExamStateProvider>
         <ExamAPIError />
       </ExamStateProvider>,
       { store },
     );
 
-    expect(queryByTestId('heading')).toBeInTheDocument();
-    expect(queryByTestId('support-link')).toBeInTheDocument();
+    expect(tree).toMatchSnapshot();
   });
 
-  it('shows generic heading with no contact info if it is not provided', () => {
-    store.getState = () => ({
-      examState: {
-        apiErrorMsg: 'Something bad has happened',
-        proctoringSettings: {},
-      },
-    });
+  it('renders support link if site name and support url are given', () => {
+    const config = {
+      SITE_NAME: 'Open edX',
+      SUPPORT_URL: 'https://support.example.org/',
+    };
+    getConfig.mockImplementation(() => config);
 
-    const { queryByTestId } = render(
+    store.getState = () => ({ examState: {} });
+
+    const { getByTestId } = render(
       <ExamStateProvider>
         <ExamAPIError />
       </ExamStateProvider>,
       { store },
     );
 
-    const heading = queryByTestId('heading');
-    const defaultMessage = 'A system error has occurred with your exam. Please reach out to support for assistance';
-    expect(heading).toBeInTheDocument();
-    expect(heading).toHaveTextContent(defaultMessage);
-    expect(queryByTestId('support-link')).not.toBeInTheDocument();
+    const supportLink = getByTestId('support-link');
+    expect(supportLink).toHaveProperty('href', config.SUPPORT_URL);
+    expect(supportLink).toHaveTextContent(`${config.SITE_NAME} Support`);
   });
 
-  it('shows error details message and can show/hide it ', () => {
+  it('renders error details when provided', () => {
     store.getState = () => ({
-      examState: {
-        apiErrorMsg: 'Something bad has happened',
-        proctoringSettings: {},
-      },
+      examState: { apiErrorMsg: 'Something bad has happened' },
     });
 
     const { queryByTestId } = render(
@@ -71,16 +68,36 @@ describe('ExamAPiError', () => {
       { store },
     );
 
-    const showButton = queryByTestId('show-button');
-    expect(showButton).toBeInTheDocument();
-    expect(showButton).toHaveTextContent('Show');
-    expect(queryByTestId('error-details')).not.toBeInTheDocument();
-    fireEvent.click(showButton);
-    expect(showButton).toHaveTextContent('Hide');
-    expect(queryByTestId('error-details')).toBeInTheDocument();
     expect(queryByTestId('error-details')).toHaveTextContent(store.getState().examState.apiErrorMsg);
-    fireEvent.click(showButton);
-    expect(showButton).toHaveTextContent('Show');
-    expect(queryByTestId('error-details')).not.toBeInTheDocument();
+  });
+
+  it('renders default message when error is HTML', () => {
+    store.getState = () => ({
+      examState: { apiErrorMsg: '<Response is HTML>' },
+    });
+
+    const { queryByTestId } = render(
+      <ExamStateProvider>
+        <ExamAPIError />
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(queryByTestId('error-details')).toHaveTextContent(defaultMessage);
+  });
+
+  it('renders default message when there is no error message', () => {
+    store.getState = () => ({
+      examState: { apiErrorMsg: '' },
+    });
+
+    const { queryByTestId } = render(
+      <ExamStateProvider>
+        <ExamAPIError />
+      </ExamStateProvider>,
+      { store },
+    );
+
+    expect(queryByTestId('error-details')).toHaveTextContent(defaultMessage);
   });
 });

--- a/src/exam/__snapshots__/ExamAPIError.test.jsx.snap
+++ b/src/exam/__snapshots__/ExamAPIError.test.jsx.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExamAPIError renders with the default information 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="fade alert alert-danger show"
+        data-testid="exam-api-error-component"
+        role="alert"
+      >
+        <span
+          class="pgn__icon alert-icon"
+        >
+          <svg
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <div
+          class="alert-heading h4"
+          data-testid="error-details"
+        >
+          A system error has occurred with your exam.
+        </div>
+        <p>
+          If the issue persists, please reach out to support for assistance, and return to the exam once you receive further instructions.
+        </p>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="fade alert alert-danger show"
+      data-testid="exam-api-error-component"
+      role="alert"
+    >
+      <span
+        class="pgn__icon alert-icon"
+      >
+        <svg
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      <div
+        class="alert-heading h4"
+        data-testid="error-details"
+      >
+        A system error has occurred with your exam.
+      </div>
+      <p>
+        If the issue persists, please reach out to support for assistance, and return to the exam once you receive further instructions.
+      </p>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/exam/messages.js
+++ b/src/exam/messages.js
@@ -1,0 +1,14 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  apiErrorDefault: {
+    id: 'exam.apiError.default',
+    defaultMessage: 'A system error has occurred with your exam.',
+  },
+  supportTextWithoutLink: {
+    id: 'exam.apiError.supportText.withoutLink',
+    defaultMessage: 'If the issue persists, please reach out to support for assistance, and return to the exam once you receive further instructions.',
+  },
+});
+
+export default messages;


### PR DESCRIPTION
https://openedx.atlassian.net/browse/MST-1266

Display the relevant error message more prominently, and fall back to a default message if there is none, or if the message is HTML. Also use the values defined in frontend config for site name + support URL, rather than relying on proctored exam settings.

Before
-------
![43aaaade-4a3d-48ee-bebe-84ee48b954fe](https://user-images.githubusercontent.com/10442143/153231188-58cfd4b3-4cc7-4a59-aff3-db74edde8019.png)

After
-----

**Using the API error message:**
![Screen Shot 2022-02-08 at 4 40 12 PM](https://user-images.githubusercontent.com/10442143/153082512-74196c37-0e61-4300-8336-9347c0b0a4dc.png)

**Default message:**
![Screen Shot 2022-02-08 at 4 39 21 PM](https://user-images.githubusercontent.com/10442143/153082505-70d7ac24-b46d-4b32-aba1-ee167c8d6ba8.png)

