### PR TITLE
fix: only deny audit and honor code learners of certain exam types

### DIFF
--- a/src/exam/Exam.jsx
+++ b/src/exam/Exam.jsx
@@ -54,11 +54,13 @@ const Exam = ({
 
   const [hasProctoredExamAccess, setHasProctoredExamAccess] = useState(true);
 
+  const proctoredExamTypes = [ExamType.ONBOARDING, ExamType.PRACTICE, ExamType.PROCTORED];
+
   useEffect(() => {
     if (examId) {
       getProctoringSettings();
     }
-    if (examType !== ExamType.TIMED) {
+    if (proctoredExamTypes.includes(examType)) {
       // Only exclude Timed Exam when restricting access to exams
       setHasProctoredExamAccess(canAccessProctoredExams);
     }

--- a/src/exam/ExamWrapper.test.jsx
+++ b/src/exam/ExamWrapper.test.jsx
@@ -320,4 +320,31 @@ describe('SequenceExamWrapper', () => {
     expect(queryByTestId('no-access')).toBeNull();
     expect(queryByTestId('sequence-content')).toHaveTextContent('children');
   });
+
+  it('learner has access to content that are not exams', () => {
+    store.getState = () => ({
+      examState: Factory.build('examState', {
+        exam: Factory.build('exam', {
+          type: '',
+          attempt: null,
+          passed_due_date: false,
+          hide_after_due: false,
+        }),
+      }),
+    });
+    const { queryByTestId } = render(
+      <ExamStateProvider>
+        <SequenceExamWrapper
+          sequence={{ ...sequence, isTimeLimited: false }}
+          courseId={courseId}
+          canAccessProctoredExams={false}
+        >
+          <div data-testid="sequence-content">children</div>
+        </SequenceExamWrapper>
+      </ExamStateProvider>,
+      { store },
+    );
+    expect(queryByTestId('no-access')).toBeNull();
+    expect(queryByTestId('sequence-content')).toHaveTextContent('children');
+  });
 });


### PR DESCRIPTION
### Description
This change fixes a bug associated with version 1.15.4 by [this PR](https://github.com/edx/frontend-lib-special-exams/pull/59).

The bug was that, the [code at frontend-lib-special-exam](https://github.com/edx/frontend-lib-special-exams/blob/main/src/exam/Exam.jsx#L61), which is part of the version 1.15.4, is excluding too much. When the content type is not of an exam type, the variable examType has the value "". I need to only check against an array of proctored exam types.

@edx/masters-devs-cosmonauts Please review