### PR TITLE
fix: ease peer dependency requirements to just major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,15 +52,15 @@
     "eventemitter3": "^4.0.7"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "1.8.4",
-    "@edx/paragon": "13.17.0",
-    "prop-types": "15.7.2",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
-    "react-redux": "7.1.3",
-    "react-router": "5.1.2",
-    "react-router-dom": "5.1.2",
-    "redux": "4.0.5",
+    "@edx/frontend-platform": "^1.8.4",
+    "@edx/paragon": "^13.17.0",
+    "prop-types": "^15.7.2",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-redux": "^7.1.3",
+    "react-router": "^5.1.2",
+    "react-router-dom": "^5.1.2",
+    "redux": "^4.0.5",
     "@reduxjs/toolkit": "^1.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The versions were so tightly defined, it made it hard for a consuming MFE to upgrade minor versions of other packages.