### PR TITLE
feat: pass external attempt id to provider js

### DIFF
--- a/src/data/messages/handlers.js
+++ b/src/data/messages/handlers.js
@@ -16,7 +16,7 @@ function workerTimeoutPromise(timeoutMilliseconds) {
 }
 
 export function workerPromiseForEventNames(eventNames, workerUrl) {
-  return (timeout) => {
+  return (timeout, attemptExternalId) => {
     const proctoringBackendWorker = createWorker(workerUrl);
     return new Promise((resolve, reject) => {
       const responseHandler = (e) => {
@@ -29,7 +29,7 @@ export function workerPromiseForEventNames(eventNames, workerUrl) {
         }
       };
       proctoringBackendWorker.addEventListener('message', responseHandler);
-      proctoringBackendWorker.postMessage({ type: eventNames.promptEventName, timeout });
+      proctoringBackendWorker.postMessage({ type: eventNames.promptEventName, timeout, attemptExternalId });
     });
   };
 }

--- a/src/data/slice.js
+++ b/src/data/slice.js
@@ -61,6 +61,7 @@ export const examSlice = createSlice({
         desktop_application_js_url: '',
         ping_interval: null,
         attempt_code: '',
+        external_id: '',
       },
       type: '',
     },

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -149,6 +149,7 @@ export function startProctoredExam() {
       const startExamTimeoutMilliseconds = EXAM_START_TIMEOUT_MILLISECONDS;
       workerPromiseForEventNames(actionToMessageTypesMap.start, exam.attempt.desktop_application_js_url)(
         startExamTimeoutMilliseconds,
+        attempt.external_id,
       ).then(() => updateAttemptAfter(
         exam.course_id, exam.content_id, continueAttempt(attempt.attempt_id),
       )(dispatch))


### PR DESCRIPTION
### [MST-1659](https://2u-internal.atlassian.net/browse/MST-1659)

Supporting PR to: https://github.com/openedx/edx-proctoring/pull/1084

Take the external id from the exam attempt and pass it off to the JS worker
